### PR TITLE
Support cache tagging

### DIFF
--- a/Configuration/Tag.php
+++ b/Configuration/Tag.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Configuration;
+
+use FOS\HttpCacheBundle\Exception\InvalidTagException;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation;
+
+/**
+ * @Annotation
+ */
+class Tag extends ConfigurationAnnotation
+{
+    protected $tags;
+    protected $expression;
+
+    public function setValue($data)
+    {
+        $this->setTags(is_array($data) ? $data: array($data));
+    }
+
+    /**
+     * @param mixed $expression
+     */
+    public function setExpression($expression)
+    {
+        $this->expression = $expression;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getExpression()
+    {
+        return $this->expression;
+    }
+
+    public function setTags(array $tags)
+    {
+        foreach ($tags as $tag) {
+            if (false !== \strpos($tag, ',')) {
+                throw new InvalidTagException($tag, ',');
+            }
+        }
+
+        $this->tags = $tags;
+    }
+
+    public function getTags()
+    {
+        return $this->tags;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliasName()
+    {
+        return 'tag';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function allowArray()
+    {
+        return true;
+    }
+} 

--- a/EventListener/TagListener.php
+++ b/EventListener/TagListener.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace FOS\HttpCacheBundle\EventListener;
+
+use FOS\HttpCacheBundle\CacheManager;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+
+class TagListener implements EventSubscriberInterface
+{
+    /**
+     * @var CacheManager
+     */
+    protected $cacheManager;
+
+    /**
+     * Constructor
+     *
+     * @param CacheManager       $cacheManager
+     * @param ExpressionLanguage $expressionLanguage
+     */
+    public function __construct(
+        CacheManager $cacheManager,
+        ExpressionLanguage $expressionLanguage = null
+    ) {
+        $this->cacheManager = $cacheManager;
+        $this->expressionLanguage = $expressionLanguage ?: new ExpressionLanguage();
+    }
+
+    /**
+     * Process the _tags request attribute, which is set when using the Tag
+     * annotation
+     *
+     * - For a safe (GET or HEAD) request, the tags are set on the response.
+     * - For a non-safe request, the tags will be invalidated.
+     *
+     * @param FilterResponseEvent $event
+     */
+    public function onKernelResponse(FilterResponseEvent $event)
+    {
+        $request = $event->getRequest();
+
+        // Check for _tag request attribute that is set when using @Tag
+        // annotation
+        if (!$tagConfigurations = $request->attributes->get('_tag')) {
+            return;
+        }
+
+        $response = $event->getResponse();
+
+        // Only set cache tags or invalidate them if response is successful
+        if (!$response->isSuccessful()) {
+            return;
+        }
+
+        $tags = array();
+        foreach ($tagConfigurations as $tagConfiguration) {
+            if (null !== $tagConfiguration->getExpression()) {
+                $tags[] = $this->expressionLanguage->evaluate(
+                    $tagConfiguration->getExpression(),
+                    $request->attributes->all()
+                );
+            } else {
+                $tags = array_merge($tags, $tagConfiguration->getTags());
+            }
+        }
+
+        $uniqueTags = array_unique($tags);
+
+        if ($request->isMethodSafe()) {
+            // For safe requests (GET and HEAD), set cache tags on response
+            $this->cacheManager->tagResponse($response, $uniqueTags);
+        } else {
+            // For non-safe methods, invalidate the tags
+            $this->cacheManager->invalidateTags($uniqueTags);
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => 'onKernelResponse'
+        );
+    }
+} 

--- a/Exception/InvalidTagException.php
+++ b/Exception/InvalidTagException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Exception;
+
+class InvalidTagException extends \InvalidArgumentException
+{
+    public function __construct($tag, $char)
+    {
+        parent:__construct(sprintf('Tag %s is invalid because it contains %s'));
+    }
+} 

--- a/Invalidation/CacheProxyInterface.php
+++ b/Invalidation/CacheProxyInterface.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Invalidation;
+
+interface CacheProxyInterface
+{
+
+} 

--- a/Invalidation/Method/BanInterface.php
+++ b/Invalidation/Method/BanInterface.php
@@ -13,6 +13,24 @@ interface BanInterface
     const CONTENT_TYPE_ALL = self::REGEX_MATCH_ALL;
 
     /**
+     * Ban cached objects matching HTTP headers
+     *
+     * Please make sure to configure your HTTP caching proxy to set the headers
+     * supplied here on the cached objects. So if you want to match objects by
+     * host name, configure your proxy to copy the host to a custom HTTP header
+     * such as X-Host.
+     *
+     * @param array $headers HTTP headers that path must match to be banned.
+     *                       Each header is either a:
+     *                       - regular string ('X-Host' => 'example.com')
+     *                       - or a POSIX regular expression
+     *                         ('X-Host' => '^(www\.)?(this|that)\.com$').
+     *
+     * @return $this
+     */
+    public function ban(array $headers);
+
+    /**
      * Ban paths matching a regular expression
      *
      * @param string $path        Path that will be banned. This can be a regex,
@@ -30,5 +48,5 @@ interface BanInterface
      *
      * @return $this
      */
-    public function ban($path, $contentType = self::CONTENT_TYPE_ALL, array $hosts = null);
+    public function banPath($path, $contentType = self::CONTENT_TYPE_ALL, array $hosts = null);
 }

--- a/Resources/doc/tagging.md
+++ b/Resources/doc/tagging.md
@@ -1,0 +1,155 @@
+Tagged Cache Invalidation
+=========================
+
+Introduction
+------------
+
+If your application has many intricate relationships between cached items,
+which makes it complex to invalidate them by route, cache tagging may be
+useful.
+
+Caching tagging, or more precisely [Tagged Cache Invalidation](http://blog.kevburnsjr.com/tagged-cache-invalidation),
+is a simpler version of [Linked Cache Invalidation](http://tools.ietf.org/html/draft-nottingham-linked-cache-inv-03)
+(LCI).
+
+Tagged Cache Invalidation allows you to:
+* assign tags to your applications’s responses (e.g., `articles`, `article-42`)
+* invalidate the responses by tag (e.g., invalidate all responses that are tagged
+  `article-42`)
+
+Configuration
+-------------
+
+See the [Varnish chapter](varnish.md#cache-tagging) on how to configure your
+Varnish proxy for tagging.
+
+Usage
+-----
+
+### Set cache tags on responses
+
+#### Manually
+
+Set tags manually on any response object:
+
+```php
+$cacheManager = $container->get('fos_http_cache.manager');
+$cacheManager->tagResponse($response, array('some-tag', 'other-tag'));
+```
+
+#### Using annotations
+
+You can also tag your response with the `@Tag` annotation.
+
+**Note:** the `@Tag` annotation has a dependency on the SensioFrameworkExtraBundle,
+so make sure to include that in your project:
+
+```bash
+$ composer require sensio/framework-extra-bundle
+```
+
+```php
+use FOS\HttpCacheBundle\Configuration\Tag;
+
+class PostController extends Controller
+{
+    /**
+     * @Tag("posts")
+     */
+    public function indexAction()
+    {
+        // ...
+    }
+}
+```
+
+When `indexAction()` returns a successful response for a safe (GET or HEAD)
+request, the response will get the tag `posts`. The tag is set in a custom
+HTTP header (`X-Cache-Tags`, by default).
+
+Multiple tags are possible:
+
+```php
+    /**
+     * @Tag("posts")
+     * @Tag("posts-list")
+     */
+    public function indexAction()
+    {
+        // ...
+    }
+```
+
+If you prefer, you can combine your tags in one annotation:
+
+```php
+    /**
+     * @Tag({"posts", "posts-list"})
+     */
+```
+
+You can also use [expressions](http://symfony.com/doc/current/components/expression_language/index.html)
+in tags.
+
+**Note:** expressions have a dependency on the Symfony’s ExpressionLanguage
+component, so make sure to include that in your project:
+
+```bash
+$ composer require symfony/expression-language
+```
+
+This will set tag `post-123` on the response:
+
+```php
+    /**
+     * @Tag(expression="'post-'~id")
+     */
+    public function showAction($id)
+    {
+        // Assume $id equals 123
+    }
+```
+
+Or, using a [param converter](http://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html):
+
+```php
+    /**
+     * @Tag(expression="'post-'~post.id")
+     */
+    public function showAction(Post $post)
+    {
+        // Assume $post->getId() returns 123
+    }
+```
+
+### Invalidate tags
+
+#### Manually
+
+```php
+$cacheManager = $container->get('fos_http_cache.manager');
+$cacheManager->invalidateTags(array('some-tag', 'other-tag'));
+```
+
+#### Using annotations
+
+Annotate your controller just like you did when setting tags:
+
+```php
+use FOS\HttpCacheBundle\Configuration\Tag;
+
+class PostController extends Controller
+{
+    /**
+     * @Tag(expression="'post'~post.id")
+     * @Tag("posts")
+     */
+    public function editAction(Post $post)
+    {
+        // Assume $post->getId() returns 123
+    }
+}
+```
+
+Any non-safe request to the `editAction` that returns a successful response
+will trigger invalidation of both `posts` and `post-123` tags.

--- a/Resources/doc/varnish.md
+++ b/Resources/doc/varnish.md
@@ -1,6 +1,9 @@
 Varnish
 =======
 
+Introduction
+------------
+
 This bundle is compatible with Varnish version 3.0 onwards. In order to use
 this bundle with Varnish, you probably have to make changes to your Varnish
 configuration.
@@ -151,4 +154,33 @@ You can now refresh a path or an absolute URL by calling the `refresh` method:
 $varnish->refresh('/my/path')
     ->refresh('http://myapp.dev/absolute/url')
     ->flush();
+```
+
+### Cache tagging
+
+Add the following to your Varnish configuration to enable
+[cache tagging](tagging.md).
+
+```varnish
+sub vcl_recv {
+    # ...
+
+    if (req.request == "BAN") {
+        # ...
+        if (req.http.x-cache-tags) {
+            ban("obj.http.host ~ " + req.http.x-host
+                + " && obj.http.x-url ~ " + req.http.x-url
+                + " && obj.http.content-type ~ " + req.http.x-content-type
+                + " && obj.http.x-cache-tags ~ " + req.http.x-cache-tags
+            );
+        } else {
+            ban("obj.http.host ~ " + req.http.x-host
+                + " && obj.http.x-url ~ " + req.http.x-url
+                + " && obj.http.content-type ~ " + req.http.x-content-type
+            );
+        }
+
+        error 200 "Banned";
+    }
+}
 ```

--- a/Tests/EventListener/Fixture/FooControllerTagAtMethod.php
+++ b/Tests/EventListener/Fixture/FooControllerTagAtMethod.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Tests\EventListener\Fixture;
+
+use FOS\HttpCacheBundle\Configuration\Tag;
+
+class FooControllerTagAtMethod
+{
+    /**
+     * @Tag({"article-1", "article-3"})
+     * @Tag("article-2s")
+     */
+    public function barAction()
+    {
+    }
+
+    public function expressionAction()
+    {
+
+    }
+} 

--- a/Tests/EventListener/InvalidationListenerTest.php
+++ b/Tests/EventListener/InvalidationListenerTest.php
@@ -18,8 +18,8 @@ class InvalidationListenerTest extends \PHPUnit_Framework_TestCase
     {
         $cacheManager = \Mockery::mock('\FOS\HttpCacheBundle\CacheManager')
             ->shouldDeferMissing()
-            ->shouldReceive('invalidateRoute')
-            ->never()
+            ->shouldReceive('invalidateRoute')->never()
+            ->shouldReceive('flush')->once()
             ->getMock();
 
         $invalidators = \Mockery::mock('\FOS\HttpCacheBundle\Invalidator\InvalidatorCollection')

--- a/Tests/EventListener/TagListenerTest.php
+++ b/Tests/EventListener/TagListenerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Test\EventListener;
+
+use FOS\HttpCacheBundle\CacheManager;
+use FOS\HttpCacheBundle\Configuration\Tag;
+use FOS\HttpCacheBundle\EventListener\TagListener;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\HttpKernelInterface;
+
+class TagListenerTest extends \PHPUnit_Framework_TestCase
+{
+    protected $cacheManager;
+
+    protected $listener;
+
+    public function setUp()
+    {
+        $this->cacheManager = \Mockery::mock(
+            '\FOS\HttpCacheBundle\CacheManager',
+            array(
+                \Mockery::mock(
+                    '\FOS\HttpCacheBundle\Invalidation\CacheProxyInterface,'
+                    . '\FOS\HttpCacheBundle\Invalidation\Method\BanInterface'
+                ),
+                \Mockery::mock('\Symfony\Component\Routing\RouterInterface')
+            )
+        )->shouldDeferMissing();
+
+        $this->listener = new TagListener($this->cacheManager);
+    }
+
+    public function testOnKernelResponseGet()
+    {
+        $tag1 = new Tag(array('value' => 'item-1'));
+        $tag2 = new Tag(array('value' => array('item-1', 'item-2')));
+
+        $request = new Request();
+        $request->setMethod('GET');
+        $request->attributes->set('_tag', array($tag1, $tag2));
+
+        $event = $this->getEvent($request);
+        $this->listener->onKernelResponse($event);
+
+        $this->assertEquals(
+            'item-1,item-2',
+            $event->getResponse()->headers->get($this->cacheManager->getTagsHeader())
+        );
+    }
+
+    public function testOnKernelResponseGetWithExpression()
+    {
+        $tag = new Tag(array('expression' => '"item-"~id'));
+
+        $request = new Request();
+        $request->setMethod('GET');
+        $request->attributes->set('_tag', array($tag));
+        $request->attributes->set('id', '123');
+
+        $event = $this->getEvent($request);
+        $this->listener->onKernelResponse($event);
+
+        $this->assertEquals(
+            'item-123',
+            $event->getResponse()->headers->get($this->cacheManager->getTagsHeader())
+        );
+    }
+
+    public function testOnKernelResponsePost()
+    {
+        $tag = new Tag(array('value' => array('item-1', 'item-2')));
+
+        $request = new Request();
+        $request->setMethod('POST');
+        $request->attributes->set('_tag', array($tag));
+
+        $event = $this->getEvent($request);
+
+        $this->cacheManager
+            ->shouldReceive('invalidateTags')
+            ->once()
+            ->with(array('item-1', 'item-2'));
+        $this->listener->onKernelResponse($event);
+    }
+
+    protected function getEvent(Request $request, Response $response = null)
+    {
+        return new FilterResponseEvent(
+            \Mockery::mock('\Symfony\Component\HttpKernel\HttpKernelInterface'),
+            $request,
+            HttpKernelInterface::MASTER_REQUEST,
+            $response ?: new Response()
+        );
+    }
+}

--- a/Tests/Functional/CacheManagerTest.php
+++ b/Tests/Functional/CacheManagerTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Tests\Functional;
+
+use FOS\HttpCacheBundle\CacheManager;
+
+class CacheManagerTest extends FunctionalTestCase
+{
+    public function testInvalidateTags()
+    {
+        $router = \Mockery::mock('\Symfony\Component\Routing\RouterInterface');
+        $cacheManager = new CacheManager($this->varnish, $router);
+
+        $this->assertMiss(self::getResponse('/tags.php'));
+        $this->assertHit(self::getResponse('/tags.php'));
+
+        $cacheManager->invalidateTags(array('tag1'))->flush();
+
+        $this->assertMiss(self::getResponse('/tags.php'));
+    }
+} 

--- a/Tests/Functional/Fixtures/varnish/fos.vcl
+++ b/Tests/Functional/Fixtures/varnish/fos.vcl
@@ -19,14 +19,27 @@ sub vcl_recv {
         if (!client.ip ~ invalidators) {
             error 405 "Not allowed.";
         }
-        ban("obj.http.host ~ " + req.http.x-host + " && obj.http.x-url ~ " + req.http.x-url + " && obj.http.content-type ~ " + req.http.x-content-type);
+
+        if (req.http.x-cache-tags) {
+            ban("obj.http.host ~ " + req.http.x-host
+                + " && obj.http.x-url ~ " + req.http.x-url
+                + " && obj.http.content-type ~ " + req.http.x-content-type
+                + " && obj.http.x-cache-tags ~ " + req.http.x-cache-tags
+            );
+        } else {
+            ban("obj.http.host ~ " + req.http.x-host
+                + " && obj.http.x-url ~ " + req.http.x-url
+                + " && obj.http.content-type ~ " + req.http.x-content-type
+            );
+        }
+
         error 200 "Banned";
     }
 }
 
 sub vcl_fetch {
 
-    # Set Ban-lurker friendly tags
+    # Set ban-lurker friendly custom headers
     set beresp.http.x-url = req.url;
     set beresp.http.x-host = req.http.host;
 
@@ -61,7 +74,7 @@ sub vcl_deliver {
             set resp.http.X-Cache = "MISS";
         }
     } else {
-        # Remove custom headers when delivering to client
+        # Remove ban-lurker friendly custom headers when delivering to client
         unset resp.http.x-url;
         unset resp.http.x-host;
     }

--- a/Tests/Functional/Fixtures/web/tags.php
+++ b/Tests/Functional/Fixtures/web/tags.php
@@ -1,0 +1,5 @@
+<?php
+header('Cache-Control: max-age=3600');
+header('Content-Type: text/html');
+header('X-Cache-Tags: tag1,tag2');
+header('X-Cache-Debug: 1');

--- a/Tests/Functional/FunctionalTestCase.php
+++ b/Tests/Functional/FunctionalTestCase.php
@@ -2,6 +2,7 @@
 
 namespace FOS\HttpCacheBundle\Tests\Functional;
 
+use FOS\HttpCacheBundle\Invalidation\Varnish;
 use Guzzle\Http\Client;
 use Guzzle\Http\Message\Response;
 
@@ -9,8 +10,21 @@ abstract class FunctionalTestCase extends \PHPUnit_Framework_TestCase
 {
     private static $client;
 
+    /**
+     * @var Varnish
+     */
+    protected $varnish;
+
     const CACHE_MISS = 'MISS';
     const CACHE_HIT  = 'HIT';
+
+    public function setUp()
+    {
+        $this->varnish = new Varnish(array('http://127.0.0.1:6081'), 'localhost:6081');
+
+        // After each test, restart Varnish to clear caches
+        exec('sudo service varnish restart');
+    }
 
     public static function getClient()
     {
@@ -23,7 +37,7 @@ abstract class FunctionalTestCase extends \PHPUnit_Framework_TestCase
 
     public static function getResponse($url)
     {
-        return self::getClient()->get($url);
+        return self::getClient()->get($url)->send();
     }
 
     public function assertMiss(Response $response, $message = null)

--- a/Tests/Functional/VarnishTest.php
+++ b/Tests/Functional/VarnishTest.php
@@ -7,64 +7,51 @@ use FOS\HttpCacheBundle\Invalidation\Varnish;
 
 class VarnishTest extends FunctionalTestCase
 {
-    /**
-     * @var Varnish
-     */
-    protected $varnish;
-
-    public function setUp()
-    {
-        $this->varnish = new Varnish(array('http://127.0.0.1:6081'), 'localhost:6081');
-
-        // After each test, restart Varnish to clear caches
-        exec('sudo service varnish restart');
-    }
-
     public function testBanAll()
     {
-        $this->assertMiss(self::getResponse('/cache.php')->send());
-        $this->assertHit(self::getResponse('/cache.php')->send());
+        $this->assertMiss(self::getResponse('/cache.php'));
+        $this->assertHit(self::getResponse('/cache.php'));
 
-        $this->assertMiss(self::getResponse('/json.php')->send());
-        $this->assertHit(self::getResponse('/json.php')->send());
+        $this->assertMiss(self::getResponse('/json.php'));
+        $this->assertHit(self::getResponse('/json.php'));
 
-        $this->varnish->ban('.*')->flush();
-        $this->assertMiss(self::getResponse('/cache.php')->send());
-        $this->assertMiss(self::getResponse('/json.php')->send());
+        $this->varnish->banPath('.*')->flush();
+        $this->assertMiss(self::getResponse('/cache.php'));
+        $this->assertMiss(self::getResponse('/json.php'));
     }
 
     public function testBanContentType()
     {
-        $this->assertMiss(self::getResponse('/cache.php')->send());
-        $this->assertHit(self::getResponse('/cache.php')->send());
+        $this->assertMiss(self::getResponse('/cache.php'));
+        $this->assertHit(self::getResponse('/cache.php'));
 
-        $this->assertMiss(self::getResponse('/json.php')->send());
-        $this->assertHit(self::getResponse('/json.php')->send());
+        $this->assertMiss(self::getResponse('/json.php'));
+        $this->assertHit(self::getResponse('/json.php'));
 
-        $this->varnish->ban('.*', 'text/html')->flush();
-        $this->assertMiss(self::getResponse('/cache.php')->send());
-        $this->assertHit(self::getResponse('/json.php')->send());
+        $this->varnish->banPath('.*', 'text/html')->flush();
+        $this->assertMiss(self::getResponse('/cache.php'));
+        $this->assertHit(self::getResponse('/json.php'));
     }
 
     public function testPurge()
     {
-        $this->assertMiss(self::getResponse('/cache.php')->send());
-        $this->assertHit(self::getResponse('/cache.php')->send());
+        $this->assertMiss(self::getResponse('/cache.php'));
+        $this->assertHit(self::getResponse('/cache.php'));
 
         $this->varnish->purge('/cache.php')->flush();
-        $this->assertMiss(self::getResponse('/cache.php')->send());
+        $this->assertMiss(self::getResponse('/cache.php'));
     }
 
     public function testRefresh()
     {
-        $this->assertMiss(self::getResponse('/cache.php')->send());
-        $response = self::getResponse('/cache.php')->send();
+        $this->assertMiss(self::getResponse('/cache.php'));
+        $response = self::getResponse('/cache.php');
         $this->assertHit($response);
 
         $this->varnish->refresh('/cache.php')->flush();
 
         sleep(1);
-        $refreshed = self::getResponse('/cache.php')->send();
+        $refreshed = self::getResponse('/cache.php');
         $this->assertGreaterThan((string) $response->getHeader('Age'), (string) $refreshed->getHeader('Age'));
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,10 @@
         "sensio/framework-extra-bundle": "~2.1",
         "symfony/expression-language": "~2.4"
     },
+    "suggest": {
+        "sensio/framework-extra-bundle": "For Tagged Cache Invalidation",
+        "symfony/expression-language": "For Tagged Cache Invalidation"
+    },
     "autoload": {
         "psr-0": { "FOS\\HttpCacheBundle": "" }
     },


### PR DESCRIPTION
Tag your HTTP cache entries, and later invalidate cache entries by tags. This is sometimes called [Tagged Cache Invalidation](http://blog.kevburnsjr.com/tagged-cache-invalidation), a simpler version of [Linked Cache Invalidation](http://tools.ietf.org/html/draft-nottingham-linked-cache-inv-03). See also [this Drupal proposal](https://groups.drupal.org/node/297773).

For Varnish, this will come down to setting a custom header on the response and then banning on that header later. 

By the way, Varnish have [their own implementation called hashtwo](https://www.varnish-software.com/blog/advanced-cache-invalidation-strategies?utm_source=twitter&utm_medium=social&utm_content=393200) that's probably more efficient, but as it's a paid solution, it's less relevant to us.

See also  http://www.gossamer-threads.com/lists/varnish/misc/19732#19732
