### PR TITLE
Add support for annotations

### DIFF
--- a/Configuration/InvalidatePath.php
+++ b/Configuration/InvalidatePath.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Configuration;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation;
+
+/**
+ * @Annotation
+ */
+class InvalidatePath extends ConfigurationAnnotation
+{
+    /**
+     * @var array
+     */
+    protected $paths;
+
+    public function setValue($data)
+    {
+        $this->setPaths((is_array($data) ? $data: array($data)));
+    }
+
+    /**
+     * @param array $paths
+     */
+    public function setPaths($paths)
+    {
+        $this->paths = $paths;
+    }
+
+    /**
+     * @return array
+     */
+    public function getPaths()
+    {
+        return $this->paths;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliasName()
+    {
+        return 'invalidate_path';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function allowArray()
+    {
+        return true;
+    }
+} 

--- a/Configuration/InvalidateRoute.php
+++ b/Configuration/InvalidateRoute.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Configuration;
+
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationAnnotation;
+
+/**
+ * @Annotation
+ */
+class InvalidateRoute extends ConfigurationAnnotation
+{
+    /**
+     * @var string
+     */
+    protected $name;
+
+    /**
+     * @var array
+     */
+    protected $params;
+
+    public function setValue($value)
+    {
+        $this->setName($value);
+    }
+
+    /**
+     * @param string $name
+     */
+    public function setName($name)
+    {
+        $this->name = $name;
+    }
+
+    /**
+     * @return string
+     */
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    /**
+     * @param array $params
+     */
+    public function setParams($params)
+    {
+        $this->params = $params;
+    }
+
+    /**
+     * @return array
+     */
+    public function getParams()
+    {
+        return $this->params;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getAliasName()
+    {
+        return 'invalidate_route';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function allowArray()
+    {
+        return true;
+    }
+} 

--- a/Resources/doc/annotations.md
+++ b/Resources/doc/annotations.md
@@ -1,0 +1,81 @@
+Annotations
+===========
+
+You can annotate your controller actions to configure routes and paths that
+should be invalidated when that action is executed.
+
+* [Requirements](#requirements)
+* [@InvalidatePath](#invalidatepath)
+* [@InvalidateRoute](#invalidateroute)
+* [@Tag](#tag)
+
+Requirements
+------------
+
+This bundle’s annotations have a dependency on the SensioFrameworkExtraBundle,
+so make sure to include that in your project:
+
+```bash
+$ composer require sensio/framework-extra-bundle
+```
+
+If you wish to use [expressions](http://symfony.com/doc/current/components/expression_language/index.html)
+in your annotations, you also need Symfony’s ExpressionLanguage component. If
+you’re not using full-stack Symfony 2.4 or later, you need to explicitly add
+the component:
+
+```bash
+$ composer require symfony/expression-language
+```
+
+@InvalidatePath
+---------------
+
+```php
+use FOS\HttpCacheBundle\Configuration\InvalidatePath;
+
+    /**
+     * @InvalidatePath("/posts")
+     * @InvalidatePath("/posts/latest")
+     */
+    public function editAction()
+    {
+    }
+}
+```
+
+@InvalidateRoute
+---------------
+
+```php
+use FOS\HttpCacheBundle\Configuration\InvalidateRoute;
+
+    /**
+     * @InvalidateRoute("posts")
+     * @InvalidateRoute("posts", params={"type" = "latest"})
+     */
+    public function editAction()
+    {
+    }
+```
+
+You can also use [expressions](http://symfony.com/doc/current/components/expression_language/index.html)
+in the route parameter values:
+
+```php
+    /**
+     * @InvalidateRoute("posts", params={"number" = "id"})
+     */
+    public function editAction(Request $request)
+    {
+        // Assume $request->attributes->get('id') returns 123
+    }
+```
+
+Route `posts` will now be invalidated with value `123` for param `number`.
+
+@Tag
+----
+
+See the [Tagging chapter](tagging.md) for more information about the `@Tag`
+annotation.


### PR DESCRIPTION
For instance:

``` php
class StuffController extends Controller
{
    /**
     * @Invalidate({
     *   routes={"route1", "route2", "route3"},
     *   paths={"/bla/bla", "/bla/bla/bla"}
     *   tags={"tag1"}
     * })
     */
    public function updateStuffAction($id, Request $request)
    {
       // ...
    }
}
```
