### PR TITLE
Replace deprecated target-dir with PSR-4 autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,8 @@
     },
     "minimum-stability": "dev",
     "autoload": {
-        "psr-0": { "FOS\\HttpCacheBundle": "" }
-    },
-    "target-dir": "FOS/HttpCacheBundle"
+        "psr-4": {
+            "FOS\\HttpCacheBundle\\": ""
+        }
+    }
 }


### PR DESCRIPTION
The Composer docs recommend replacing `target-dir`, which is now [deprecated](https://getcomposer.org/doc/04-schema.md#target-dir), with PSR-4 autoloading.
