### PR TITLE
Fix tests on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
   - SYMFONY_VERSION=dev-master
 
 before_script:
-  - composer require symfony/framework-bundle:${SYMFONY_VERSION}
+  - composer require --dev symfony/framework-bundle:${SYMFONY_VERSION} symfony/symfony:${SYMFONY_VERSION}
 
 script: phpunit --coverage-clover=coverage.clover
 


### PR DESCRIPTION
This (hopefully) fixes the tests failures we’re seeing, for instance in #41, since we’ve included `symfony/symfony` in `require-dev`.  
