### PR TITLE
adjust to namespace refactoring

### DIFF
--- a/CacheManager.php
+++ b/CacheManager.php
@@ -3,7 +3,7 @@
 namespace FOS\HttpCacheBundle;
 
 use FOS\HttpCache\CacheInvalidator;
-use FOS\HttpCache\Invalidation\CacheProxyInterface;
+use FOS\HttpCache\ProxyClient\ProxyClientInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\RouterInterface;
 
@@ -23,10 +23,10 @@ class CacheManager extends CacheInvalidator
     /**
      * Constructor
      *
-     * @param CacheProxyInterface $cache  HTTP cache
-     * @param RouterInterface     $router Symfony router
+     * @param ProxyClientInterface $cache  HTTP cache
+     * @param RouterInterface      $router Symfony router
      */
-    public function __construct(CacheProxyInterface $cache, RouterInterface $router)
+    public function __construct(ProxyClientInterface $cache, RouterInterface $router)
     {
         parent::__construct($cache);
         $this->router = $router;

--- a/Resources/config/varnish.xml
+++ b/Resources/config/varnish.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="fos_http_cache.varnish.class">FOS\HttpCache\Invalidation\Varnish</parameter>
+        <parameter key="fos_http_cache.varnish.class">FOS\HttpCache\ProxyClient\Varnish</parameter>
     </parameters>
 
     <services>

--- a/Tests/Unit/EventListener/TagListenerTest.php
+++ b/Tests/Unit/EventListener/TagListenerTest.php
@@ -21,7 +21,7 @@ class TagListenerTest extends \PHPUnit_Framework_TestCase
         $this->cacheManager = \Mockery::mock(
             '\FOS\HttpCacheBundle\CacheManager',
             array(
-                \Mockery::mock('\FOS\HttpCache\Invalidation\Method\BanInterface'),
+                \Mockery::mock('\FOS\HttpCache\ProxyClient\Invalidation\BanInterface'),
                 \Mockery::mock('\Symfony\Component\Routing\RouterInterface')
             )
         )->shouldDeferMissing();

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "guzzle/http": "*",
         "guzzle/plugin-mock": "*",
-        "mockery/mockery": "0.8.*",
+        "mockery/mockery": "0.9.*",
         "monolog/monolog": "*",
         "sensio/framework-extra-bundle": "~2.3",
         "symfony/symfony": "~2.3",
@@ -42,7 +42,6 @@
         "sensio/framework-extra-bundle": "For Tagged Cache Invalidation",
         "symfony/expression-language": "For Tagged Cache Invalidation"
     },
-    "minimum-stability": "dev",
     "autoload": {
         "psr-4": {
             "FOS\\HttpCacheBundle\\": ""


### PR DESCRIPTION
 and upgrade to mockery 0.9 to be compatible with phpunit 4. and adjust some tests to be compatible with the undocumented mockery BC break done in https://github.com/padraic/mockery/issues/144

fix #45
