### PR TITLE
change all event listeners to event subscribers

### DIFF
--- a/EventListener/CacheAuthorizationSubscriber.php
+++ b/EventListener/CacheAuthorizationSubscriber.php
@@ -2,19 +2,32 @@
 
 namespace FOS\HttpCacheBundle\EventListener;
 
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * listen to HEAD requests, return response after security, but before Controller is invoked
+ * Listen to HEAD requests, return response after security, but before
+ * Controller is invoked.
  *
  * @author Stefan Paschke <stefan.paschke@gmail.com>
  */
-class CacheAuthorizationListener
+class CacheAuthorizationSubscriber implements EventSubscriberInterface
 {
-   /**
-    * @param GetResponseEvent $event
-    */
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::REQUEST => 'onKernelRequest',
+        );
+    }
+
+    /**
+     * @param GetResponseEvent $event
+     */
     public function onKernelRequest(GetResponseEvent $event)
     {
         $request = $event->getRequest();

--- a/EventListener/CacheControlSubscriber.php
+++ b/EventListener/CacheControlSubscriber.php
@@ -2,10 +2,12 @@
 
 namespace FOS\HttpCacheBundle\EventListener;
 
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
 /**
@@ -15,7 +17,7 @@ use Symfony\Component\Security\Core\SecurityContextInterface;
  *
  * @author Lea Haensenberger <lea.haensenberger@gmail.com>
  */
-class CacheControlListener
+class CacheControlSubscriber implements EventSubscriberInterface
 {
     /**
      * @var SecurityContextInterface
@@ -59,6 +61,16 @@ class CacheControlListener
     {
         $this->securityContext = $securityContext;
         $this->debugHeader = $debugHeader;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        );
     }
 
     /**

--- a/EventListener/FlashMessageSubscriber.php
+++ b/EventListener/FlashMessageSubscriber.php
@@ -2,18 +2,20 @@
 
 namespace FOS\HttpCacheBundle\EventListener;
 
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpFoundation\Cookie;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpKernel\HttpKernel;
+use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * This listener reads all flash messages and moves them into a cookie.
+ * This event handler reads all flash messages and moves them into a cookie.
  *
  * @author Lukas Kahwe Smith <smith@pooteeweet.org>
  */
-class FlashMessageListener
+class FlashMessageSubscriber implements EventSubscriberInterface
 {
     /**
      * @var array
@@ -35,6 +37,16 @@ class FlashMessageListener
     {
         $this->session = $session;
         $this->options = $options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            KernelEvents::RESPONSE => 'onKernelResponse',
+        );
     }
 
    /**

--- a/EventListener/InvalidationSubscriber.php
+++ b/EventListener/InvalidationSubscriber.php
@@ -18,12 +18,12 @@ use Symfony\Component\HttpKernel\Event\PostResponseEvent;
 use Symfony\Component\Routing\RouterInterface;
 
 /**
- * On kernel.terminate event, this listener invalidates routes for the current
- * request and flushes the CacheManager.
+ * On kernel.terminate event, this event handler invalidates routes for the
+ * current request and flushes the CacheManager.
  *
  * @author David de Boer <david@driebit.nl>
  */
-class InvalidationListener implements EventSubscriberInterface
+class InvalidationSubscriber implements EventSubscriberInterface
 {
     /**
      * Cache manager

--- a/EventListener/TagSubscriber.php
+++ b/EventListener/TagSubscriber.php
@@ -3,12 +3,18 @@
 namespace FOS\HttpCacheBundle\EventListener;
 
 use FOS\HttpCacheBundle\CacheManager;
+use FOS\HttpCacheBundle\Configuration\Tag;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 
-class TagListener implements EventSubscriberInterface
+/**
+ * Event handler for the cache tagging tags.
+ *
+ * @author David de Boer <david@driebit.nl>
+ */
+class TagSubscriber implements EventSubscriberInterface
 {
     /**
      * @var CacheManager
@@ -44,6 +50,7 @@ class TagListener implements EventSubscriberInterface
 
         // Check for _tag request attribute that is set when using @Tag
         // annotation
+        /** @var $tagConfigurations Tag[] */
         if (!$tagConfigurations = $request->attributes->get('_tag')) {
             return;
         }
@@ -87,4 +94,4 @@ class TagListener implements EventSubscriberInterface
             KernelEvents::RESPONSE => 'onKernelResponse'
         );
     }
-} 
+}

--- a/Resources/config/authorization_request_listener.xml
+++ b/Resources/config/authorization_request_listener.xml
@@ -5,13 +5,13 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="fos_http_cache.event_listener.cache_authorization.class">FOS\HttpCacheBundle\EventListener\CacheAuthorizationListener</parameter>
+        <parameter key="fos_http_cache.event_listener.cache_authorization.class">FOS\HttpCacheBundle\EventListener\CacheAuthorizationSubscriber</parameter>
     </parameters>
 
     <services>
         <service id="fos_http_cache.event_listener.cache_authorization"
                  class="%fos_http_cache.event_listener.cache_authorization.class%">
-            <tag name="kernel.event_listener" event="kernel.request" method="onKernelRequest" priority="-129" />
+            <tag name="kernel.event_subscriber" />
         </service>
     </services>
 </container>

--- a/Resources/config/cache_control_listener.xml
+++ b/Resources/config/cache_control_listener.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="fos_http_cache.event_listener.cache_control.class">FOS\HttpCacheBundle\EventListener\CacheControlListener</parameter>
+        <parameter key="fos_http_cache.event_listener.cache_control.class">FOS\HttpCacheBundle\EventListener\CacheControlSubscriber</parameter>
         <parameter key="fos_http_cache.request_matcher.class">Symfony\Component\HttpFoundation\RequestMatcher</parameter>
     </parameters>
 
@@ -14,7 +14,7 @@
                  class="%fos_http_cache.event_listener.cache_control.class%">
             <argument type="service" id="security.context" on-invalid="ignore"/>
             <argument>%fos_http_cache.debug_header%</argument>
-            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
+            <tag name="kernel.event_subscriber" />
         </service>
 
         <service id="fos_http_cache.request_matcher"

--- a/Resources/config/cache_manager.xml
+++ b/Resources/config/cache_manager.xml
@@ -7,7 +7,7 @@
     <parameters>
         <parameter key="fos_http_cache.cache_manager.class">FOS\HttpCacheBundle\CacheManager</parameter>
         <parameter key="fos_http_cache.event_listener.log.class">FOS\HttpCache\EventListener\LogSubscriber</parameter>
-        <parameter key="fos_http_cache.event_listener.invalidation.class">FOS\HttpCacheBundle\EventListener\InvalidationListener</parameter>
+        <parameter key="fos_http_cache.event_listener.invalidation.class">FOS\HttpCacheBundle\EventListener\InvalidationSubscriber</parameter>
     </parameters>
 
     <services>

--- a/Resources/config/flash_message_listener.xml
+++ b/Resources/config/flash_message_listener.xml
@@ -5,7 +5,7 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="fos_http_cache.event_listener.flash_message.class">FOS\HttpCacheBundle\EventListener\FlashMessageListener</parameter>
+        <parameter key="fos_http_cache.event_listener.flash_message.class">FOS\HttpCacheBundle\EventListener\FlashMessageSubscriber</parameter>
     </parameters>
 
     <services>
@@ -13,7 +13,7 @@
                  class="%fos_http_cache.event_listener.flash_message.class%">
             <argument type="service" id="session"/>
             <argument>%fos_http_cache.event_listener.flash_message.options%</argument>
-            <tag name="kernel.event_listener" event="kernel.response" method="onKernelResponse" />
+            <tag name="kernel.event_subscriber" />
         </service>
     </services>
 </container>

--- a/Resources/config/tag_listener.xml
+++ b/Resources/config/tag_listener.xml
@@ -5,14 +5,14 @@
     xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="fos_http_cache.event_listener.tag.class">FOS\HttpCacheBundle\EventListener\TagListener</parameter>
+        <parameter key="fos_http_cache.event_listener.tag.class">FOS\HttpCacheBundle\EventListener\TagSubscriber</parameter>
     </parameters>
 
     <services>
         <service id="fos_http_cache.event_listener.tag"
                  class="%fos_http_cache.event_listener.tag.class%">
             <argument type="service" id="fos_http_cache.cache_manager" />
-            <tag name="kernel.event_subscriber" event="kernel.response" />
+            <tag name="kernel.event_subscriber" />
         </service>
     </services>
 </container>

--- a/Tests/Functional/EventListener/TagSubscriberTest.php
+++ b/Tests/Functional/EventListener/TagSubscriberTest.php
@@ -4,7 +4,7 @@ namespace FOS\HttpCacheBundle\Tests\Functional\EventListener;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
-class TagListenerTest extends WebTestCase
+class TagSubscriberTest extends WebTestCase
 {
     public function testTagsAreSet()
     {

--- a/Tests/Unit/EventListener/CacheAuthorizationSubscriberTest.php
+++ b/Tests/Unit/EventListener/CacheAuthorizationSubscriberTest.php
@@ -2,12 +2,12 @@
 
 namespace FOS\HttpCacheBundle\Tests\Unit\EventListener;
 
-use FOS\HttpCacheBundle\EventListener\CacheAuthorizationListener;
+use FOS\HttpCacheBundle\EventListener\CacheAuthorizationSubscriber;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 
-class CacheAuthorizationListenerTest extends \PHPUnit_Framework_TestCase
+class CacheAuthorizationSubscriberTest extends \PHPUnit_Framework_TestCase
 {
     public function testHeadRequest()
     {
@@ -15,7 +15,7 @@ class CacheAuthorizationListenerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('HEAD');
         $event = $this->getEvent($request);
 
-        $listener = new CacheAuthorizationListener();
+        $listener = new CacheAuthorizationSubscriber();
         $listener->onKernelRequest($event);
         $this->assertTrue($event->hasResponse());
     }
@@ -26,7 +26,7 @@ class CacheAuthorizationListenerTest extends \PHPUnit_Framework_TestCase
         $request->setMethod('GET');
         $event = $this->getEvent($request);
 
-        $listener = new CacheAuthorizationListener();
+        $listener = new CacheAuthorizationSubscriber();
         $listener->onKernelRequest($event);
         $this->assertFalse($event->hasResponse());
     }

--- a/Tests/Unit/EventListener/CacheControlSubscriberTest.php
+++ b/Tests/Unit/EventListener/CacheControlSubscriberTest.php
@@ -3,7 +3,7 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\EventListener;
 
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
-use FOS\HttpCacheBundle\EventListener\CacheControlListener;
+use FOS\HttpCacheBundle\EventListener\CacheControlSubscriber;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\HttpFoundation\Request;
@@ -11,11 +11,11 @@ use Symfony\Component\HttpFoundation\RequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 
-class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
+class CacheControlSubscriberTest extends \PHPUnit_Framework_TestCase
 {
     public function testDefaultHeaders()
     {
-        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlListener')
+        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlSubscriber')
             ->setMethods(array('getOptions'))
             ->getMock();
 
@@ -45,7 +45,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testExtraHeaders()
     {
-        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlListener')
+        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlSubscriber')
             ->setMethods(array('getOptions'))
             ->getMock();
 
@@ -72,7 +72,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testCompoundHeaders()
     {
-        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlListener')
+        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlSubscriber')
             ->setMethods(array('getOptions'))
             ->getMock();
 
@@ -105,7 +105,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testSetNoCacheHeaders()
     {
-        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlListener')
+        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlSubscriber')
             ->setMethods(array('getOptions'))
             ->getMock();
 
@@ -139,7 +139,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testVary()
     {
-        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlListener')
+        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlSubscriber')
             ->setMethods(array('getOptions'))
             ->getMock();
 
@@ -165,7 +165,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testReverseProxyTtl()
     {
-        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlListener')
+        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlSubscriber')
             ->setMethods(array('getOptions'))
             ->getMock();
 
@@ -189,7 +189,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testDebug()
     {
-        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlListener')
+        $listener = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlSubscriber')
             ->setMethods(array('getOptions'))
             ->setConstructorArgs(array(null, 'X-Cache-Debug'))
             ->getMock();
@@ -245,7 +245,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
 
     public function testMatchRuleWithActionName()
     {
-        $listener = new \FOS\HttpCacheBundle\EventListener\CacheControlListener();
+        $listener = new \FOS\HttpCacheBundle\EventListener\CacheControlSubscriber();
 
         $headers = array( 'controls' => array(
             'etag' => '1337',
@@ -293,7 +293,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
         $security = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
 
 
-        $listener = new CacheControlListener($security);
+        $listener = new CacheControlSubscriber($security);
         $listener->add(
             new RequestMatcher(),
             array(

--- a/Tests/Unit/EventListener/InvalidationSubscriberTest.php
+++ b/Tests/Unit/EventListener/InvalidationSubscriberTest.php
@@ -4,7 +4,7 @@ namespace FOS\HttpCacheBundle\Tests\Unit\EventListener;
 
 use FOS\HttpCacheBundle\Configuration\InvalidatePath;
 use FOS\HttpCacheBundle\Configuration\InvalidateRoute;
-use FOS\HttpCacheBundle\EventListener\InvalidationListener;
+use FOS\HttpCacheBundle\EventListener\InvalidationSubscriber;
 use FOS\HttpCacheBundle\Invalidator\Invalidator;
 use FOS\HttpCacheBundle\Invalidator\InvalidatorCollection;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -15,7 +15,7 @@ use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 use \Mockery;
 
-class InvalidationListenerTest extends \PHPUnit_Framework_TestCase
+class InvalidationSubscriberTest extends \PHPUnit_Framework_TestCase
 {
     protected $cacheManager;
     protected $invalidators;
@@ -78,7 +78,7 @@ class InvalidationListenerTest extends \PHPUnit_Framework_TestCase
         $invalidators = new InvalidatorCollection();
         $invalidators->addInvalidator($invalidator);
 
-        $listener = new InvalidationListener($cacheManager, $invalidators, $router);
+        $listener = new InvalidationSubscriber($cacheManager, $invalidators, $router);
 
         $request = new Request();
         $request->attributes->set('_route', 'route_invalidator');
@@ -153,7 +153,7 @@ class InvalidationListenerTest extends \PHPUnit_Framework_TestCase
 
     protected function getListener()
     {
-        return new InvalidationListener(
+        return new InvalidationSubscriber(
             $this->cacheManager,
             $this->invalidators,
             \Mockery::mock('\Symfony\Component\Routing\RouterInterface')

--- a/Tests/Unit/EventListener/TagSubscriberTest.php
+++ b/Tests/Unit/EventListener/TagSubscriberTest.php
@@ -4,13 +4,13 @@ namespace FOS\HttpCacheBundle\Test\Unit\EventListener;
 
 use FOS\HttpCacheBundle\CacheManager;
 use FOS\HttpCacheBundle\Configuration\Tag;
-use FOS\HttpCacheBundle\EventListener\TagListener;
+use FOS\HttpCacheBundle\EventListener\TagSubscriber;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class TagListenerTest extends \PHPUnit_Framework_TestCase
+class TagSubscriberTest extends \PHPUnit_Framework_TestCase
 {
     protected $cacheManager;
 
@@ -26,7 +26,7 @@ class TagListenerTest extends \PHPUnit_Framework_TestCase
             )
         )->shouldDeferMissing();
 
-        $this->listener = new TagListener($this->cacheManager);
+        $this->listener = new TagSubscriber($this->cacheManager);
     }
 
     public function testOnKernelResponseGet()


### PR DESCRIPTION
fix #46

i have a slight naming confusion: do we still keep the EventListener namespace like other bundles do, or do we change all to EventSubscriber and the service ids to event_subscriber?
