### PR TITLE
Improved the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,29 @@ php:
   - 5.3
   - 5.4
   - 5.5
+  - 5.6
+  - hhvm
 
-env:
-  - SYMFONY_VERSION=2.3.*
-  - SYMFONY_VERSION=2.4.*
-  - SYMFONY_VERSION=dev-master
+branches:
+  only:
+    - master
+    - /^\d+\.\d+$/
+
+matrix:
+  include:
+    - php: 5.5
+      env: SYMFONY_VERSION='2.3.*'
+    - php: 5.5
+      env: SYMFONY_VERSION='2.4.*'
+    - php: 5.5
+      env: SYMFONY_VERSION='dev-master'
+  allow_failure:
+    - php: hhvm
+
 
 before_script:
-  - composer require --dev symfony/symfony:${SYMFONY_VERSION}
+  - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
+  - composer install
 
 script: phpunit --coverage-clover=coverage.clover
 


### PR DESCRIPTION
- add testing on HHVM and PHP 5.6
- test the non-latest versions of Symfony only once instead of doing it for all PHP versions, thus reducing the matrix
- build only the master branch and the release branches to avoid extra builds when using the main repo for feature branches
- let composer use individual components and bundles for the normal resolution of Symfony
