### PR TITLE
fix x-cache-debug header is always sent

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -29,6 +29,19 @@ use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 class Configuration implements ConfigurationInterface
 {
     /**
+     * @var bool
+     */
+    private $debug;
+
+    /**
+     * @param Boolean $debug Whether to use the debug mode
+     */
+    public function __construct($debug)
+    {
+        $this->debug = $debug;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function getConfigTreeBuilder()
@@ -51,8 +64,8 @@ class Configuration implements ConfigurationInterface
 
             ->children()
                 ->booleanNode('debug')
-                    ->defaultValue('%kernel.debug%')
-                    ->info('Whether to send a debug header with the response to trigger a caching proxy to send debug information.')
+                    ->defaultValue($this->debug)
+                    ->info('Whether to send a debug header with the response to trigger a caching proxy to send debug information. If not set, defaults to kernel.debug.')
                 ->end()
                 ->scalarNode('debug_header')
                     ->defaultValue('X-Cache-Debug')

--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -31,12 +31,12 @@ class FOSHttpCacheExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
-        $configuration = new Configuration();
+        $configuration = new Configuration($container->getParameter('kernel.debug'));
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
 
-        if (($config['debug']) || (!empty($config['rules']))) {
+        if ($config['debug'] || (!empty($config['rules']))) {
             $debugHeader = $config['debug'] ? $config['debug_header'] : false;
             $container->setParameter($this->getAlias().'.debug_header', $debugHeader);
             $loader->load('cache_control_listener.xml');

--- a/Tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCacheBundle\Tests\Unit\DependencyInjection;
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
+use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
 class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
 {
@@ -29,7 +30,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigLoadVarnish()
     {
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load(array($this->getBaseConfig()), $container);
 
         $this->assertTrue($container->hasDefinition('fos_http_cache.proxy_client.varnish'));
@@ -41,7 +42,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
     {
         $config = array();
 
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load(array($config), $container);
     }
 
@@ -70,7 +71,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load(array($config), $container);
     }
 
@@ -101,7 +102,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load($config, $container);
 
         // Extract the corresponding definition
@@ -168,7 +169,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
             ))
         );
 
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load($config, $container);
 
         // Extract the corresponding definition
@@ -208,15 +209,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
             )
         );
 
-        $container = new ContainerBuilder();
-        $this->extension->load($config, $container);
-    }
-
-    public function testConfigLoadRulesDefaults()
-    {
-        $config = array();
-
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load($config, $container);
     }
 
@@ -236,7 +229,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
             )),
         );
 
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load($config, $container);
 
         $this->assertTrue($container->has('fos_http_cache.event_listener.user_context'));
@@ -264,7 +257,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
             )),
         );
 
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load($config, $container);
 
         $this->assertFalse($container->has('fos_http_cache.event_listener.user_context'));
@@ -285,7 +278,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
             )),
         );
 
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load($config, $container);
     }
 
@@ -296,8 +289,15 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
             ),
         );
 
-        $container = new ContainerBuilder();
+        $container = $this->createContainer();
         $this->extension->load($config, $container);
+    }
+
+    protected function createContainer()
+    {
+        return new ContainerBuilder(new ParameterBag(array(
+            'kernel.debug'       => false,
+        )));
     }
 
     protected function getBaseConfig()


### PR DESCRIPTION
i noticed that i had a misconception that parameters would be used in the configuration class.
