### PR TITLE
Add hash invalidation on logout

### DIFF
--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -167,6 +167,10 @@ class FOSHttpCacheExtension extends Extension
             ->replaceArgument(3, $config['user_hash_header'])
             ->replaceArgument(4, $config['hash_cache_ttl']);
 
+        $container->getDefinition($this->getAlias().'.user_context.logout_handler')
+            ->replaceArgument(1, $config['user_identifier_headers'])
+            ->replaceArgument(2, $config['match']['accept']);
+
         if ($config['role_provider']) {
             $container->getDefinition($this->getAlias().'.user_context.role_provider')
                 ->addTag(UserContextListenerPass::TAG_NAME)

--- a/Resources/config/user_context.xml
+++ b/Resources/config/user_context.xml
@@ -9,6 +9,7 @@
         <parameter key="fos_http_cache.user_context.hash_generator.class">FOS\HttpCache\UserContext\HashGenerator</parameter>
         <parameter key="fos_http_cache.user_context.role_provider.class">FOS\HttpCacheBundle\UserContext\RoleProvider</parameter>
         <parameter key="fos_http_cache.user_context.request_matcher.class">FOS\HttpCacheBundle\UserContext\RequestMatcher</parameter>
+        <parameter key="fos_http_cache.user_context.logout_handler.class">FOS\HttpCacheBundle\Security\Http\Logout\ContextInvalidationLogoutHandler</parameter>
     </parameters>
 
     <services>
@@ -31,6 +32,12 @@
 
         <service id="fos_http_cache.user_context.role_provider" class="%fos_http_cache.user_context.role_provider.class%" abstract="true">
             <argument type="service" id="security.context" on-invalid="ignore" />
+        </service>
+
+        <service id="fos_http_cache.user_context.logout_handler" class="%fos_http_cache.user_context.logout_handler.class%">
+            <argument type="service" id="fos_http_cache.default_proxy_client" />
+            <argument />
+            <argument />
         </service>
     </services>
 </container>

--- a/Resources/doc/event-subscribers/user-context.rst
+++ b/Resources/doc/event-subscribers/user-context.rst
@@ -125,6 +125,31 @@ If the hash only depends on the ``Authorization`` header and should be cached fo
           - Authorization
         hash_cache_ttl: 900
 
+You will need to invalidate this cache when the user context will change (e.g. on
+login, logout, ...)
+
+With the default configuration of security in Symfony, the session id is regenerated
+for the login and logout action. You have to be sure that the ``invalidate_session``
+configuration key is set to true in your firewall configuration.
+
+To invalidate the cache on the caching proxy, a logout handler named
+``fos_http_cache.user_context.logout_handler`` can be add in your firewall.
+Your caching proxy needs to support BAN operations for this to work.
+
+.. code-block:: yaml
+
+    # app/config/security.yml
+    security:
+      firewalls:
+        secured_area:
+          logout:
+            invalidate_session: true
+            handlers:
+              - fos_http_cache.user_context.logout_handler
+
+This handler will automatically send requests to ban the hash cache of the user
+on logout.
+
 The User Context
 ----------------
 

--- a/Security/Http/Logout/ContextInvalidationLogoutHandler.php
+++ b/Security/Http/Logout/ContextInvalidationLogoutHandler.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCacheBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCacheBundle\Security\Http\Logout;
+
+use FOS\HttpCache\ProxyClient\Invalidation\BanInterface;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
+
+class ContextInvalidationLogoutHandler implements LogoutHandlerInterface
+{
+    /**
+     * Service used to ban hash request
+     *
+     * @var \FOS\HttpCache\ProxyClient\Invalidation\BanInterface
+     */
+    private $banner;
+
+    /**
+     * Accept header
+     *
+     * @var string
+     */
+    private $acceptHeader;
+
+    /**
+     * User identifier headers
+     *
+     * @var string[]
+     */
+    private $userIdentifierHeaders;
+
+    public function __construct(BanInterface $banner, $userIdentifierHeaders, $acceptHeader)
+    {
+        $this->banner                = $banner;
+        $this->acceptHeader          = $acceptHeader;
+        $this->userIdentifierHeaders = $userIdentifierHeaders;
+    }
+
+    /**
+     * Invalidate the user context hash
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param TokenInterface $token
+     */
+    public function logout(Request $request, Response $response, TokenInterface $token)
+    {
+        $sessionId = $request->getSession()->getId();
+
+        foreach ($this->userIdentifierHeaders as $header) {
+            $this->banner->ban(array(
+                'accept' => $this->acceptHeader,
+                $header => sprintf('.*%s.*', $sessionId)
+            ));
+        }
+    }
+}

--- a/Tests/Functional/Fixtures/Session/TestSessionStorage.php
+++ b/Tests/Functional/Fixtures/Session/TestSessionStorage.php
@@ -1,0 +1,171 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Tests\Functional\Fixtures\Session;
+
+use Symfony\Component\HttpFoundation\Session\SessionBagInterface;
+use Symfony\Component\HttpFoundation\Session\Storage\MetadataBag;
+use Symfony\Component\HttpFoundation\Session\Storage\SessionStorageInterface;
+use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+
+class TestSessionStorage implements SessionStorageInterface
+{
+    private $started = false;
+
+    private $bags = array();
+
+    /**
+     * Starts the session.
+     *
+     * @throws \RuntimeException If something goes wrong starting the session.
+     *
+     * @return bool    True if started.
+     *
+     * @api
+     */
+    public function start()
+    {
+        $this->started = true;
+    }
+
+    /**
+     * Checks if the session is started.
+     *
+     * @return bool    True if started, false otherwise.
+     */
+    public function isStarted()
+    {
+        return $this->started;
+    }
+
+    /**
+     * Returns the session ID
+     *
+     * @return string The session ID or empty.
+     *
+     * @api
+     */
+    public function getId()
+    {
+        return 'test';
+    }
+
+    /**
+     * Sets the session ID
+     *
+     * @param string $id
+     *
+     * @api
+     */
+    public function setId($id)
+    {
+    }
+
+    /**
+     * Returns the session name
+     *
+     * @return mixed The session name.
+     *
+     * @api
+     */
+    public function getName()
+    {
+        return 'TESTSESSID';
+    }
+
+    /**
+     * Sets the session name
+     *
+     * @param string $name
+     *
+     * @api
+     */
+    public function setName($name)
+    {
+    }
+
+    /**
+     * Regenerates id that represents this storage.
+     *
+     * This method must invoke session_regenerate_id($destroy) unless
+     * this interface is used for a storage object designed for unit
+     * or functional testing where a real PHP session would interfere
+     * with testing.
+     *
+     * Note regenerate+destroy should not clear the session data in memory
+     * only delete the session data from persistent storage.
+     *
+     * @param bool $destroy Destroy session when regenerating?
+     * @param int $lifetime Sets the cookie lifetime for the session cookie. A null value
+     *                          will leave the system settings unchanged, 0 sets the cookie
+     *                          to expire with browser session. Time is in seconds, and is
+     *                          not a Unix timestamp.
+     *
+     * @return bool    True if session regenerated, false if error
+     *
+     * @throws \RuntimeException If an error occurs while regenerating this storage
+     *
+     * @api
+     */
+    public function regenerate($destroy = false, $lifetime = null)
+    {
+        return true;
+    }
+
+    /**
+     * Force the session to be saved and closed.
+     *
+     * This method must invoke session_write_close() unless this interface is
+     * used for a storage object design for unit or functional testing where
+     * a real PHP session would interfere with testing, in which case it
+     * it should actually persist the session data if required.
+     *
+     * @throws \RuntimeException If the session is saved without being started, or if the session
+     *                           is already closed.
+     */
+    public function save()
+    {
+    }
+
+    /**
+     * Clear all session data in memory.
+     */
+    public function clear()
+    {
+    }
+
+    /**
+     * Gets a SessionBagInterface by name.
+     *
+     * @param string $name
+     *
+     * @return SessionBagInterface
+     *
+     * @throws \InvalidArgumentException If the bag does not exist
+     */
+    public function getBag($name)
+    {
+        return $this->bags[$name];
+    }
+
+    /**
+     * Registers a SessionBagInterface for use.
+     *
+     * @param SessionBagInterface $bag
+     */
+    public function registerBag(SessionBagInterface $bag)
+    {
+        if ($bag->getName() == "attributes") {
+            $bag->set('_security_secured_area', serialize(new UsernamePasswordToken('user', 'user', 'in_memory', array('ROLE_USER'))));
+        }
+
+        $this->bags[$bag->getName()] = $bag;
+    }
+
+    /**
+     * @return MetadataBag
+     */
+    public function getMetadataBag()
+    {
+        return null;
+    }
+}

--- a/Tests/Functional/Fixtures/app/AppKernel.php
+++ b/Tests/Functional/Fixtures/app/AppKernel.php
@@ -14,6 +14,7 @@ class AppKernel extends Kernel
             new \Symfony\Bundle\FrameworkBundle\FrameworkBundle(),
             new \Sensio\Bundle\FrameworkExtraBundle\SensioFrameworkExtraBundle(),
             new \Symfony\Bundle\MonologBundle\MonologBundle(),
+            new \Symfony\Bundle\SecurityBundle\SecurityBundle(),
             new \FOS\HttpCacheBundle\FOSHttpCacheBundle(),
         );
     }
@@ -48,5 +49,18 @@ class AppKernel extends Kernel
     protected function getContainerBaseClass()
     {
         return '\PSS\SymfonyMockerContainer\DependencyInjection\MockerContainer';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function prepareContainer(\Symfony\Component\DependencyInjection\ContainerBuilder $container)
+    {
+        parent::prepareContainer($container);
+
+        $container->setDefinition(
+            'session.test_storage',
+            new \Symfony\Component\DependencyInjection\Definition('FOS\HttpCacheBundle\Tests\Functional\Fixtures\Session\TestSessionStorage')
+        );
     }
 }

--- a/Tests/Functional/Fixtures/app/config/config.yml
+++ b/Tests/Functional/Fixtures/app/config/config.yml
@@ -3,6 +3,8 @@ framework:
   router:
     resource: "%kernel.root_dir%/config/routing.yml"
   test: ~
+  session:
+    storage_id:  session.test_storage
 
 fos_http_cache:
   cache_control:
@@ -21,9 +23,31 @@ fos_http_cache:
         match:
           path: ^/cached
         tags: [area]
+  user_context:
+    user_identifier_headers:
+      - Cookie
+      - Authorization
+    role_provider: ~
 
 monolog:
   handlers:
     main:
       type: stream
       level: debug
+
+security:
+  providers:
+    in_memory:
+      memory:
+        users:
+          user:  { password: user, roles: 'ROLE_USER' }
+  encoders:
+    Symfony\Component\Security\Core\User\User: plaintext
+  firewalls:
+    secured_area:
+      pattern:    ^/secured_area
+      anonymous:
+      logout:
+        path:     /secured_area/logout
+        handlers:
+          - fos_http_cache.user_context.logout_handler

--- a/Tests/Functional/Fixtures/app/config/routing.yml
+++ b/Tests/Functional/Fixtures/app/config/routing.yml
@@ -19,3 +19,6 @@ test_cached:
 test_noncached:
   pattern:  /noncached
   defaults:  { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\TestController::contentAction }
+
+test_logout:
+  pattern:  /secured_area/logout

--- a/Tests/Functional/Security/Http/Logout/ContextInvalidationLogoutHandlerTest.php
+++ b/Tests/Functional/Security/Http/Logout/ContextInvalidationLogoutHandlerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Tests\Functional\Security\Http\Logout;
+
+use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\BrowserKit\Cookie;
+
+class ContextInvalidationLogoutHandlerTest extends WebTestCase
+{
+    public function testLogout()
+    {
+        $client = static::createClient();
+        $client->getContainer()->mock(
+            'fos_http_cache.proxy_client.varnish',
+            '\FOS\HttpCache\ProxyClient\Varnish'
+        )
+            ->shouldReceive('ban')->once()->with(array('accept'=>'application/vnd.fos.user-context-hash', 'Cookie' => '.*test.*'))
+            ->shouldReceive('ban')->once()->with(array('accept'=>'application/vnd.fos.user-context-hash', 'Authorization' => '.*test.*'))
+            ->shouldReceive('flush')->once()
+        ;
+
+        $client->getCookieJar()->set(new Cookie('TESTSESSID', 'test'));
+        $client->request('GET', '/secured_area/logout');
+    }
+} 


### PR DESCRIPTION
Add a LogoutHandler to use with Symfony security component to ban hash request when a user logout

see #68
