### PR TITLE
define all commands as services

### DIFF
--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -59,7 +59,7 @@ class FOSHttpCacheExtension extends Extension
         }
 
         if ($config['cache_manager']['enabled']) {
-            $this->loadCacheManager($container, $loader, $config['cache_manager']);
+            $loader->load('cache_manager.xml');
         }
 
 
@@ -246,17 +246,6 @@ class FOSHttpCacheExtension extends Extension
         $container->setParameter($this->getAlias() . '.proxy_client.nginx.servers', $config['servers']);
         $container->setParameter($this->getAlias() . '.proxy_client.nginx.base_url', $config['base_url']);
         $container->setParameter($this->getAlias() . '.proxy_client.nginx.purge_location', $config['purge_location']);
-    }
-
-    private function loadCacheManager(ContainerBuilder $container, XmlFileLoader $loader, array $config)
-    {
-        $loader->load('cache_manager.xml');
-        if (version_compare(Kernel::VERSION, '2.4.0', '>=')) {
-            $container
-                ->getDefinition('fos_http_cache.command.invalidate_path')
-                ->addTag('console.command')
-            ;
-        }
     }
 
     private function loadTagRules(ContainerBuilder $container, array $config)

--- a/Resources/config/cache_manager.xml
+++ b/Resources/config/cache_manager.xml
@@ -8,6 +8,9 @@
         <parameter key="fos_http_cache.cache_manager.class">FOS\HttpCacheBundle\CacheManager</parameter>
         <parameter key="fos_http_cache.event_listener.log.class">FOS\HttpCache\EventListener\LogSubscriber</parameter>
         <parameter key="fos_http_cache.command.invalidate_path.class">FOS\HttpCacheBundle\Command\InvalidatePathCommand</parameter>
+        <parameter key="fos_http_cache.command.invalidate_regex.class">FOS\HttpCacheBundle\Command\InvalidateRegexCommand</parameter>
+        <parameter key="fos_http_cache.command.invalidate_tag.class">FOS\HttpCacheBundle\Command\InvalidateTagCommand</parameter>
+        <parameter key="fos_http_cache.command.refresh_path.class">FOS\HttpCacheBundle\Command\RefreshPathCommand</parameter>
     </parameters>
 
     <services>
@@ -26,8 +29,26 @@
             <argument type="service" id="logger" />
         </service>
 
+        <!-- for symfony < 2.4 the command will be instantiated by the framework and the command services are ignored -->
+
         <service id="fos_http_cache.command.invalidate_path" class="%fos_http_cache.command.invalidate_path.class%">
             <argument type="service" id="fos_http_cache.cache_manager" />
+            <tag name="console.command"/>
+        </service>
+
+        <service id="fos_http_cache.command.invalidate_regex" class="%fos_http_cache.command.invalidate_regex.class%">
+            <argument type="service" id="fos_http_cache.cache_manager" />
+            <tag name="console.command"/>
+        </service>
+
+        <service id="fos_http_cache.command.invalidate_tag" class="%fos_http_cache.command.invalidate_tag.class%">
+            <argument type="service" id="fos_http_cache.cache_manager" />
+            <tag name="console.command"/>
+        </service>
+
+        <service id="fos_http_cache.command.refresh_path" class="%fos_http_cache.command.refresh_path.class%">
+            <argument type="service" id="fos_http_cache.cache_manager" />
+            <tag name="console.command"/>
         </service>
     </services>
 


### PR DESCRIPTION
we seem to have only defined one command as service. adding the others as well.

or should we not define them as service by default?
