### PR TITLE
Fix tags config

### DIFF
--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -70,7 +70,7 @@ class FOSHttpCacheExtension extends Extension
                 if (!empty($config['tags']['rules'])) {
                     $this->loadTagRules($container, $config['tags']['rules']);
                 }
-            } elseif (true === $config['tag_listener']['enabled']) {
+            } elseif (true === $config['tags']['enabled']) {
                 // silently skip if set to auto
                 throw new InvalidConfigurationException('The TagListener requires symfony/expression-language and needs the cache_manager to be configured');
             }
@@ -83,7 +83,7 @@ class FOSHttpCacheExtension extends Extension
                 if (!empty($config['invalidation']['rules'])) {
                     $this->loadInvalidatorRules($container, $config['invalidation']['rules']);
                 }
-            } elseif (true === $config['tag_listener']['enabled']) {
+            } elseif (true === $config['tags']['enabled']) {
                 // silently skip if set to auto
                 throw new InvalidConfigurationException('The InvalidationListener requires symfony/expression-language and needs the cache_manager to be configured');
             }


### PR DESCRIPTION
Fix "PHP Notice:  Undefined index: tag_listener in friendsofsymfony/http-cache-bundle/DependencyInjection/FOSHttpCacheExtension.php
on line 73" when ExpressionLanguage is not available.

A problem here is that we only test on Travis with ExpressionLanguage installed, so we're not able to check all config cases. We may want to add tests where we don’t install ExpressionLanguage to check whether our config is compatible with Symfony LTS 2.3 (from 2.4 onwards ExpressionLanguage ships with Symfony full-stack).
