### PR TITLE
Add headers as optional params while invalidating/refreshing

### DIFF
--- a/CacheManager.php
+++ b/CacheManager.php
@@ -74,12 +74,13 @@ class CacheManager extends CacheInvalidator
      *
      * @param string $name       Route name
      * @param array  $parameters Route parameters (optional)
+     * @param array  $headers    Extra HTTP headers to send to the caching proxy (optional)
      *
      * @return $this
      */
-    public function invalidateRoute($name, array $parameters = array())
+    public function invalidateRoute($name, array $parameters = array(), array $headers = array())
     {
-        $this->invalidatePath($this->urlGenerator->generate($name, $parameters));
+        $this->invalidatePath($this->urlGenerator->generate($name, $parameters), $headers);
 
         return $this;
     }
@@ -89,12 +90,13 @@ class CacheManager extends CacheInvalidator
      *
      * @param string $route      Route name
      * @param array  $parameters Route parameters (optional)
+     * @param array  $headers    Extra HTTP headers to send to the caching proxy (optional)
      *
      * @return $this
      */
-    public function refreshRoute($route, array $parameters = array())
+    public function refreshRoute($route, array $parameters = array(), array $headers = array())
     {
-        $this->refreshPath($this->urlGenerator->generate($route, $parameters));
+        $this->refreshPath($this->urlGenerator->generate($route, $parameters), $headers);
 
         return $this;
     }

--- a/Resources/doc/features/invalidation.rst
+++ b/Resources/doc/features/invalidation.rst
@@ -18,7 +18,7 @@ Cache Manager
 -------------
 
 To invalidate single paths, URLs and routes manually, use the
-``invalidatePath($path)`` and ``invalidateRoute($route, $params)`` methods on
+``invalidatePath($path, $headers)`` and ``invalidateRoute($route, $params, $headers)`` methods on
 the cache manager::
 
     $cacheManager = $container->get('fos_http_cache.cache_manager');
@@ -32,6 +32,10 @@ the cache manager::
     // Invalidate a route
     $cacheManager->invalidateRoute('user_details', array('id' => 123))->flush();
 
+    // Invalidate a route or path with headers
+    $cacheManager->invalidatePath('/users', array('X-Foo' => 'bar'))->flush();
+    $cacheManager->invalidateRoute('user_details', array('id' => 123), array('X-Foo' => 'bar'))->flush();
+
 To invalidate multiple representations matching a regular expression, call
 ``invalidateRegex($path, $contentType, $hosts)``::
 
@@ -40,6 +44,13 @@ To invalidate multiple representations matching a regular expression, call
 To refresh paths and routes, you can use ``refreshPath($path)`` and
 ``refreshRoute($route, $params)`` in a similar manner. See
 :doc:`/reference/cache-manager` for more information.
+
+
+By default, the proxy clients instantiate a `Guzzle client`_ to communicate
+with the caching proxy. If you need to customize the requests, for example to
+send a basic authentication header, you can inject a custom Guzzle client::
+See the
+:doc:`/reference/configuration/proxy-client#custom-guzzle-client` configuration reference.
 
 .. _invalidation configuration:
 

--- a/Tests/Unit/CacheManagerTest.php
+++ b/Tests/Unit/CacheManagerTest.php
@@ -27,8 +27,9 @@ class CacheManagerTest extends \PHPUnit_Framework_TestCase
     public function testInvalidateRoute()
     {
         $httpCache = \Mockery::mock('\FOS\HttpCache\ProxyClient\Invalidation\PurgeInterface')
-            ->shouldReceive('purge')->once()->with('/my/route')
-            ->shouldReceive('purge')->once()->with('/route/with/params/id/123')
+            ->shouldReceive('purge')->once()->with('/my/route', array())
+            ->shouldReceive('purge')->once()->with('/route/with/params/id/123', array())
+            ->shouldReceive('purge')->once()->with('/route/with/params/id/123', array('X-Foo' => 'bar'))
             ->shouldReceive('flush')->once()
             ->getMock();
 
@@ -46,6 +47,7 @@ class CacheManagerTest extends \PHPUnit_Framework_TestCase
 
         $cacheManager->invalidateRoute('my_route')
             ->invalidateRoute('route_with_params', array('id' => 123))
+            ->invalidateRoute('route_with_params', array('id' => 123), array('X-Foo' => 'bar'))
             ->flush();
     }
 
@@ -54,6 +56,7 @@ class CacheManagerTest extends \PHPUnit_Framework_TestCase
         $httpCache = \Mockery::mock('\FOS\HttpCache\ProxyClient\Invalidation\RefreshInterface')
             ->shouldReceive('refresh')->once()->with('/my/route', null)
             ->shouldReceive('refresh')->once()->with('/route/with/params/id/123', null)
+            ->shouldReceive('refresh')->once()->with('/route/with/params/id/123', array('X-Foo' => 'bar'))
             ->shouldReceive('flush')->never()
             ->getMock();
 
@@ -72,6 +75,7 @@ class CacheManagerTest extends \PHPUnit_Framework_TestCase
         $cacheManager
             ->refreshRoute('my_route')
             ->refreshRoute('route_with_params', array('id' => 123))
+            ->refreshRoute('route_with_params', array('id' => 123), array('X-Foo' => 'bar'))
         ;
     }
 


### PR DESCRIPTION
As discussed in https://github.com/FriendsOfSymfony/FOSHttpCache/issues/117

Depends on https://github.com/FriendsOfSymfony/FOSHttpCache/pull/119
