### PR TITLE
Remove custom Guzzle client docs from feature

### DIFF
--- a/Resources/doc/features/invalidation.rst
+++ b/Resources/doc/features/invalidation.rst
@@ -45,13 +45,6 @@ To refresh paths and routes, you can use ``refreshPath($path)`` and
 ``refreshRoute($route, $params)`` in a similar manner. See
 :doc:`/reference/cache-manager` for more information.
 
-
-By default, the proxy clients instantiate a `Guzzle client`_ to communicate
-with the caching proxy. If you need to customize the requests, for example to
-send a basic authentication header, you can inject a custom Guzzle client::
-See the
-:doc:`/reference/configuration/proxy-client#custom-guzzle-client` configuration reference.
-
 .. _invalidation configuration:
 
 Configuration

--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -98,7 +98,7 @@ The cache manager however will only use the default client.
 Custom Guzzle Client
 --------------------
 
-By default, the proxy client instantiates a Guzzle_ object to talk with the
+By default, the proxy client instantiates a `Guzzle client`_ to talk with the
 caching proxy. If you need to customize the requests, for example to send a
 basic authentication header, you can configure a service and specify that in
 the ``guzzle_client`` option. A sample service definition for using basic
@@ -119,4 +119,4 @@ You need to configure your caching proxy (Varnish or Nginx) to work with this
 bundle. Please refer to the :ref:`FOSHttpCache library’s documentation <foshttpcache:proxy-configuration>`
 for more information.
 
-.. _Guzzle: http://guzzle3.readthedocs.org/
+.. _Guzzle client: http://guzzle3.readthedocs.org/


### PR DESCRIPTION
The information seems too detailed to be shown in Features, so have it in
Configuration only instead.
