### PR TITLE
invalide/refresh Route should generate absolute urls

### DIFF
--- a/CacheManager.php
+++ b/CacheManager.php
@@ -30,6 +30,13 @@ class CacheManager extends CacheInvalidator
     private $urlGenerator;
 
     /**
+     * What type of urls to generate.
+     *
+     * @var bool|string
+     */
+    private $generateUrlType = UrlGeneratorInterface::ABSOLUTE_PATH;
+
+    /**
      * Constructor
      *
      * @param ProxyClientInterface  $cache        HTTP cache proxy client
@@ -39,6 +46,16 @@ class CacheManager extends CacheInvalidator
     {
         parent::__construct($cache);
         $this->urlGenerator = $urlGenerator;
+    }
+
+    /**
+     * Set what type of URLs to generate.
+     *
+     * @param bool|string $generateUrlType One of the constants in UrlGeneratorInterface
+     */
+    public function setGenerateUrlType($generateUrlType)
+    {
+        $this->generateUrlType = $generateUrlType;
     }
 
     /**
@@ -80,7 +97,7 @@ class CacheManager extends CacheInvalidator
      */
     public function invalidateRoute($name, array $parameters = array(), array $headers = array())
     {
-        $this->invalidatePath($this->urlGenerator->generate($name, $parameters), $headers);
+        $this->invalidatePath($this->urlGenerator->generate($name, $parameters, $this->generateUrlType), $headers);
 
         return $this;
     }
@@ -96,7 +113,7 @@ class CacheManager extends CacheInvalidator
      */
     public function refreshRoute($route, array $parameters = array(), array $headers = array())
     {
-        $this->refreshPath($this->urlGenerator->generate($route, $parameters), $headers);
+        $this->refreshPath($this->urlGenerator->generate($route, $parameters, $this->generateUrlType), $headers);
 
         return $this;
     }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -16,6 +16,7 @@ use Symfony\Component\Config\Definition\Builder\NodeBuilder;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * This class contains the configuration information for the bundle
@@ -449,6 +450,17 @@ class Configuration implements ConfigurationInterface
                             ->values(array(true, false, 'auto'))
                             ->defaultValue('auto')
                             ->info('Allows to disable the invalidation manager. Enabled by default if you configure a proxy client.')
+                        ->end()
+                        ->enumNode('generate_url_type')
+                            ->values(array(
+                                'auto',
+                                UrlGeneratorInterface::ABSOLUTE_PATH,
+                                UrlGeneratorInterface::ABSOLUTE_URL,
+                                UrlGeneratorInterface::NETWORK_PATH,
+                                UrlGeneratorInterface::RELATIVE_PATH,
+                            ))
+                            ->defaultValue('auto')
+                            ->info('Set what URLs to generate on invalidate/refresh Route. Auto means path if base_url is set on the default proxy client, full URL otherwise.')
                         ->end()
                     ->end()
         ;

--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -19,6 +19,7 @@ use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 /**
  * {@inheritdoc}
@@ -62,6 +63,16 @@ class FOSHttpCacheExtension extends Extension
         }
 
         if ($config['cache_manager']['enabled']) {
+            if ('auto' === $config['cache_manager']['generate_url_type']) {
+                $defaultClient = $this->getDefault($config['proxy_client']);
+                $generateUrlType = isset($config['proxy_client'][$defaultClient]['base_url'])
+                    ? UrlGeneratorInterface::ABSOLUTE_PATH
+                    : UrlGeneratorInterface::ABSOLUTE_URL
+                ;
+            } else {
+                $generateUrlType = $config['cache_manager']['generate_url_type'];
+            }
+            $container->setParameter($this->getAlias().'.cache_manager.generate_url_type', $generateUrlType);
             $loader->load('cache_manager.xml');
         }
 

--- a/Resources/config/cache_manager.xml
+++ b/Resources/config/cache_manager.xml
@@ -21,6 +21,9 @@
             <call method="setEventDispatcher">
                 <argument id="event_dispatcher" type="service" on-invalid="ignore" />
             </call>
+            <call method="setGenerateUrlType">
+                <argument>%fos_http_cache.cache_manager.generate_url_type%</argument>
+            </call>
         </service>
 
         <service id="fos_http_cache.event_listener.log"

--- a/Resources/doc/reference/configuration.rst
+++ b/Resources/doc/reference/configuration.rst
@@ -8,6 +8,7 @@ for the bundle.
     :maxdepth: 2
 
     configuration/proxy-client
+    configuration/cache-manager
     configuration/headers
     configuration/invalidation
     configuration/tags

--- a/Resources/doc/reference/configuration/cache-manager.rst
+++ b/Resources/doc/reference/configuration/cache-manager.rst
@@ -1,0 +1,32 @@
+cache_manager
+=============
+
+The cache manager is the primary interface to invalidate caches. It is enabled
+by default if a :doc:`Proxy Client <proxy-client>` is configured.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    fos_http_cache:
+        cache_manager:
+            enabled: true
+            generate_url_type: true
+
+enabled
+-------
+
+**type**: ``enum`` **options**: ``auto``, ``true``, ``false``
+
+Whether the cache manager service should be enabled. By default, it is enabled
+if a proxy client is configured. It can not be enabled without a proxy client.
+
+generate_url_type
+-----------------
+
+**type**: ``enum`` **options**: ``auto``, ``true``, ``false``, ``relative``, ``network``
+
+The ``$referenceType`` to be used when generating URLs in the invalidateRoute and
+refreshRoute calls. True results in absolute URLs including the current domain,
+``false`` generates a path without domain, needing a ``base_url`` to be configured
+on the proxy client. When set to ``auto``, the value is determined based on ``base_url``
+of the default proxy client.

--- a/Tests/Unit/CacheManagerTest.php
+++ b/Tests/Unit/CacheManagerTest.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCacheBundle\Tests\Unit;
 use FOS\HttpCacheBundle\CacheManager;
 use \Mockery;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
 class CacheManagerTest extends \PHPUnit_Framework_TestCase
 {
@@ -35,11 +36,11 @@ class CacheManagerTest extends \PHPUnit_Framework_TestCase
 
         $router = \Mockery::mock('\Symfony\Component\Routing\Generator\UrlGeneratorInterface')
             ->shouldReceive('generate')
-            ->with('my_route', array())
+            ->with('my_route', array(), UrlGeneratorInterface::ABSOLUTE_PATH)
             ->andReturn('/my/route')
 
             ->shouldReceive('generate')
-            ->with('route_with_params', array('id' => 123))
+            ->with('route_with_params', array('id' => 123), UrlGeneratorInterface::ABSOLUTE_PATH)
             ->andReturn('/route/with/params/id/123')
             ->getMock();
 
@@ -62,11 +63,11 @@ class CacheManagerTest extends \PHPUnit_Framework_TestCase
 
         $router = \Mockery::mock('\Symfony\Component\Routing\Generator\UrlGeneratorInterface')
             ->shouldReceive('generate')
-            ->with('my_route', array())
+            ->with('my_route', array(), UrlGeneratorInterface::ABSOLUTE_PATH)
             ->andReturn('/my/route')
 
             ->shouldReceive('generate')
-            ->with('route_with_params', array('id' => 123))
+            ->with('route_with_params', array('id' => 123), UrlGeneratorInterface::ABSOLUTE_PATH)
             ->andReturn('/route/with/params/id/123')
             ->getMock();
 

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -93,6 +93,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             ),
             'cache_manager' => array(
                 'enabled' => true,
+                'generate_url_type' => 'auto',
             ),
             'tags' => array(
                 'enabled' => 'auto',
@@ -193,6 +194,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             ),
         );
         $expectedConfiguration['cache_manager']['enabled'] = 'auto';
+        $expectedConfiguration['cache_manager']['generate_url_type'] = 'auto';
         $expectedConfiguration['tags']['enabled'] = 'auto';
         $expectedConfiguration['invalidation']['enabled'] = 'auto';
         $expectedConfiguration['user_context']['logout_handler']['enabled'] = 'auto';
@@ -250,6 +252,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             ),
         );
         $expectedConfiguration['cache_manager']['enabled'] = 'auto';
+        $expectedConfiguration['cache_manager']['generate_url_type'] = 'auto';
         $expectedConfiguration['tags']['enabled'] = 'auto';
         $expectedConfiguration['invalidation']['enabled'] = 'auto';
         $expectedConfiguration['user_context']['logout_handler']['enabled'] = 'auto';
@@ -418,6 +421,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         return array(
             'cache_manager' => array(
                 'enabled' => false,
+                'generate_url_type' => 'auto',
             ),
             'tags' => array(
                 'enabled' => false,


### PR DESCRIPTION
stumbled over this. when i don't configure the host name as base path, invalidation fails. even if i configure it, just generating the path could invalidate the wrong thing in a multidomain setup where the base path is not set to the currently used domain.
