### PR TITLE
tags on auto should silently not activate when SensioFrameworkExtraBundle is missing

### DIFF
--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -66,6 +66,10 @@ class FOSHttpCacheExtension extends Extension
         }
 
         if ($config['tags']['enabled']) {
+            $bundles = $container->getParameter('kernel.bundles');
+            if (!isset($bundles['SensioFrameworkExtraBundle']) && true === $config['tags']['enabled']) {
+                throw new InvalidConfigurationException('Tag support requires the SensioFrameworkExtraBundle for annotations');
+            }
             // true or auto
             $loader->load('tag_listener.xml');
             if (!empty($config['tags']['rules'])) {


### PR DESCRIPTION
when using the bundle without SensioFrameworkExtraBundle, we get currently an error with the default configuration.
