### PR TITLE
do not enforce sensio extra bundle with default configuration

### DIFF
--- a/DependencyInjection/Compiler/TagSubscriberPass.php
+++ b/DependencyInjection/Compiler/TagSubscriberPass.php
@@ -24,7 +24,7 @@ class TagSubscriberPass implements CompilerPassInterface
      */
     public function process(ContainerBuilder $container)
     {
-        if ($container->has('fos_http_cache.event_listener.tag')
+        if (true === $container->getParameter('fos_http_cache.compiler_pass.tag_annotations')
             && !$container->has('sensio_framework_extra.controller.listener')
         ) {
             throw new \RuntimeException(

--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -65,6 +65,7 @@ class FOSHttpCacheExtension extends Extension
             $loader->load('cache_manager.xml');
         }
 
+        $container->setParameter($this->getAlias() . '.compiler_pass.tag_annotations', $config['tags']['enabled']);
         if ($config['tags']['enabled']) {
             // true or auto
             $loader->load('tag_listener.xml');


### PR DESCRIPTION
we seem to have an on and off with this question.

the problem with checking like it was done before is that you can't use FOSHttpCacheBundle without SensioFrameworkExtraBundle in the default configuration, which is a bad developer experience. Whats more, you can't use the tag handler with rulesets even though that would be technically possible without annotations.

the problem with the change i propose here is that people might do annotations that are ignored. but if they use controller annotations, chances are they also use SensioFrameworkExtraBundle. the fix i do is kind of strange, i say that the default config with "auto" does not lead to the check, while the explicit `true` does. but that config is about tag listener in general, not annotations. should we have an addittional configuration whether to check for annotations support that is off by default? that would feel weird as chances are low people ever care about that setting... ideas?
