### PR TITLE
Add configuration for logout handler

### DIFF
--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -176,9 +176,13 @@ class FOSHttpCacheExtension extends Extension
             ->replaceArgument(3, $config['user_hash_header'])
             ->replaceArgument(4, $config['hash_cache_ttl']);
 
-        $container->getDefinition($this->getAlias().'.user_context.logout_handler')
-            ->replaceArgument(1, $config['user_identifier_headers'])
-            ->replaceArgument(2, $config['match']['accept']);
+        if ($config['logout_handler']['enabled']) {
+            $container->getDefinition($this->getAlias().'.user_context.logout_handler')
+                ->replaceArgument(1, $config['user_identifier_headers'])
+                ->replaceArgument(2, $config['match']['accept']);
+        } else {
+            $container->removeDefinition($this->getAlias().'.user_context.logout_handler');
+        }
 
         if ($config['role_provider']) {
             $container->getDefinition($this->getAlias().'.user_context.role_provider')

--- a/Resources/doc/reference/configuration/user-context.rst
+++ b/Resources/doc/reference/configuration/user-context.rst
@@ -118,8 +118,11 @@ request. However, when you decide to cache hash responses, you must invalidate
 them when the user context changes, particularly when the user logs in or out.
 This bundle provides a logout handler that takes care of this for you.
 
-Logout Handler
-""""""""""""""
+logout_handler
+~~~~~~~~~~~~~~
+
+The logout handler will invalidate any cached user hashes when the user logs
+out.
 
 For the handler to work:
 
@@ -139,6 +142,16 @@ Add the handler to your firewall configuration:
                     invalidate_session: true
                     handlers:
                         - fos_http_cache.user_context.logout_handler
+
+enabled
+"""""""
+
+**type**: ``enum`` **default**: ``auto`` **options**: ``true``, ``false``, ``auto``
+
+Defauts to ``auto``, which enables the logout handler service if a
+:doc:`proxy client </reference/configuration/proxy-client>` is configured.
+Set to ``true`` to explicitly enable the logout handler. This will throw an
+exception if no proxy client is configured. 
 
 user_identifier_headers
 ~~~~~~~~~~~~~~~~~~~~~~~

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -151,6 +151,9 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'user_identifier_headers' => array('Cookie', 'Authorization'),
                 'user_hash_header' => 'FOS-User-Context-Hash',
                 'role_provider' => true,
+                'logout_handler' => array(
+                    'enabled' => 'auto',
+                ),
             ),
             'flash_message' => array(
                 'enabled' => true,
@@ -192,6 +195,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $expectedConfiguration['cache_manager']['enabled'] = 'auto';
         $expectedConfiguration['tags']['enabled'] = 'auto';
         $expectedConfiguration['invalidation']['enabled'] = 'auto';
+        $expectedConfiguration['user_context']['logout_handler']['enabled'] = 'auto';
 
         $formats = array_map(function ($path) {
             return __DIR__.'/../../Resources/Fixtures/'.$path;
@@ -248,6 +252,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         $expectedConfiguration['cache_manager']['enabled'] = 'auto';
         $expectedConfiguration['tags']['enabled'] = 'auto';
         $expectedConfiguration['invalidation']['enabled'] = 'auto';
+        $expectedConfiguration['user_context']['logout_handler']['enabled'] = 'auto';
 
         $formats = array_map(function ($path) {
             return __DIR__.'/../../Resources/Fixtures/'.$path;
@@ -436,6 +441,9 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'user_identifier_headers' => array('Cookie', 'Authorization'),
                 'user_hash_header' => 'X-User-Context-Hash',
                 'role_provider' => false,
+                'logout_handler' => array(
+                    'enabled' => false
+                ),
             ),
             'flash_message' => array(
                 'enabled' => false,

--- a/Tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -92,6 +92,8 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
 
         $container = $this->createContainer();
         $this->extension->load(array($config), $container);
+        
+        $this->assertFalse($container->has('fos_http_cache.user_context.logout_handler'));
     }
 
     public function testConfigLoadTagRules()
@@ -214,8 +216,8 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
 
     public function testConfigUserContext()
     {
-        $config = array(
-            array('user_context' => array(
+        $config = $this->getBaseConfig() + array(
+            'user_context' => array(
                 'match'   => array(
                     'matcher_service' => 'my_request_matcher_id',
                     'method' => 'AUTHENTICATE',
@@ -225,17 +227,18 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
                 'user_hash_header' => 'X-Bar',
                 'hash_cache_ttl' => 30,
                 'role_provider' => true
-            )),
+            ),
         );
 
         $container = $this->createContainer();
-        $this->extension->load($config, $container);
+        $this->extension->load(array($config), $container);
 
         $this->assertTrue($container->has('fos_http_cache.event_listener.user_context'));
         $this->assertTrue($container->has('fos_http_cache.user_context.hash_generator'));
         $this->assertTrue($container->has('fos_http_cache.user_context.request_matcher'));
         $this->assertTrue($container->has('fos_http_cache.user_context.role_provider'));
-
+        $this->assertTrue($container->has('fos_http_cache.user_context.logout_handler'));
+        
         $this->assertEquals(array('fos_http_cache.user_context.role_provider' => array(array())), $container->findTaggedServiceIds('fos_http_cache.user_context_provider'));
     }
 
@@ -263,6 +266,7 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($container->has('fos_http_cache.user_context.hash_generator'));
         $this->assertFalse($container->has('fos_http_cache.user_context.request_matcher'));
         $this->assertFalse($container->has('fos_http_cache.user_context.role_provider'));
+        $this->assertFalse($container->has('fos_http_cache.user_context.logout_handler'));
     }
 
     public function testConfigLoadFlashMessageSubscriber()


### PR DESCRIPTION
Currently, setting `user_context: enabled` will throw an exception if no proxy client is configured because of the logout handler, which requires the client. This PR solves that by adding a `user_context.logout_handler.enabled` config option, which defaults to auto, so won't be available without a proxy client.
