### PR TITLE
Get rid of build failures with symfony 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,8 +33,14 @@ matrix:
         - SYMFONY_VERSION='2.7.*@dev'
         - FRAMEWORK_EXTRA_VERSION='~3.0'
 
+# only needed for the hackaround for https://github.com/symfony/symfony/issues/12868
+before_install:
+  - sudo apt-get install -qq bc
+
 before_script:
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
+  # hackaround until https://github.com/symfony/symfony/issues/12868 is fixed
+  - bash -c 'FLAWED_DEPRECATIONS=`echo "${SYMFONY_VERSION:0:3} >= 2.7"|bc`; if [ "$FLAWED_DEPRECATIONS" = "1" ]; then echo "error_reporting = E_ALL & ~E_DEPRECATED" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini; echo "PHPUnit_Framework_Error_Deprecated::\$enabled = false;" >> Tests/bootstrap.php; fi;'
   - sh -c 'if [ "$FRAMEWORK_EXTRA_VERSION" != "" ]; then composer require --dev --no-update sensio/framework-extra-bundle=$FRAMEWORK_EXTRA_VERSION; fi;'
   - composer install
   - sudo apt-get install python-sphinx


### PR DESCRIPTION
Symfony 2.7 calls its own deprecated methods, raising warnings that break the build if we treat deprecated as an error...

Fix #176
