### PR TITLE
Fix Travis buid

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "symfony/framework-bundle": "~2.3"
     },
     "require-dev": {
+        "friendsofsymfony/http-cache": "~1.2@dev",
         "mockery/mockery": "0.9.*",
         "monolog/monolog": "*",
         "sensio/framework-extra-bundle": "~2.3",
@@ -45,7 +46,6 @@
             "FOS\\HttpCacheBundle\\": ""
         }
     },
-    "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
             "dev-master": "1.2.x-dev"


### PR DESCRIPTION
I *think* we only needed `minimum-stability: dev` for testing against the dev version of the http-cache library. Unfortunately, all other vendors then got included in their dev versions too. It may be better to work with stable vendor versions (except http-cache) so our tests will suffer less from volatile vendors such as Symfony adding deprecation warnings, for instance. (We catch those warnings for our tests that run against dev version of Symfony thanks to #180.)