### PR TITLE
Always load request_matcher and rule_matcher services

### DIFF
--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -43,6 +43,7 @@ class FOSHttpCacheExtension extends Extension
         $config = $this->processConfiguration($configuration, $configs);
 
         $loader = new XmlFileLoader($container, new FileLocator(__DIR__.'/../Resources/config'));
+        $loader->load('matcher.xml');
 
         if ($config['debug']['enabled'] || (!empty($config['cache_control']))) {
             $debugHeader = $config['debug']['enabled'] ? $config['debug']['header'] : false;

--- a/Resources/config/cache_control_listener.xml
+++ b/Resources/config/cache_control_listener.xml
@@ -6,8 +6,6 @@
 
     <parameters>
         <parameter key="fos_http_cache.event_listener.cache_control.class">FOS\HttpCacheBundle\EventListener\CacheControlSubscriber</parameter>
-        <parameter key="fos_http_cache.request_matcher.class">Symfony\Component\HttpFoundation\RequestMatcher</parameter>
-        <parameter key="fos_http_cache.rule_matcher.class">FOS\HttpCacheBundle\Http\RuleMatcher</parameter>
     </parameters>
 
     <services>
@@ -15,19 +13,6 @@
                  class="%fos_http_cache.event_listener.cache_control.class%">
             <argument>%fos_http_cache.debug_header%</argument>
             <tag name="kernel.event_subscriber" />
-        </service>
-
-        <service id="fos_http_cache.request_matcher"
-                 class="%fos_http_cache.request_matcher.class%"
-                 public="false"
-        />
-
-        <service id="fos_http_cache.rule_matcher"
-                 class="%fos_http_cache.rule_matcher.class%"
-                 public="false"
-        >
-            <argument/>
-            <argument/>
         </service>
     </services>
 </container>

--- a/Resources/config/matcher.xml
+++ b/Resources/config/matcher.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <parameters>
+        <parameter key="fos_http_cache.request_matcher.class">Symfony\Component\HttpFoundation\RequestMatcher</parameter>
+        <parameter key="fos_http_cache.rule_matcher.class">FOS\HttpCacheBundle\Http\RuleMatcher</parameter>
+    </parameters>
+
+    <services>
+        <service id="fos_http_cache.request_matcher"
+                 class="%fos_http_cache.request_matcher.class%"
+                 public="false"
+        />
+        
+        <service id="fos_http_cache.rule_matcher"
+                 class="%fos_http_cache.rule_matcher.class%"
+                 public="false"
+        >
+            <argument/>
+            <argument/>
+        </service>
+    </services>
+</container>

--- a/Tests/Unit/DependencyInjection/Compiler/HashGeneratorPassTest.php
+++ b/Tests/Unit/DependencyInjection/Compiler/HashGeneratorPassTest.php
@@ -43,7 +43,7 @@ class HashGeneratorPassTest extends \PHPUnit_Framework_TestCase
         $config = $this->getBaseConfig();
         $this->extension->load(array($config), $container);
         $this->userContextListenerPass->process($container);
-        $this->assertCount(10, $container->getDefinitions());
+        $this->assertCount(12, $container->getDefinitions());
     }
 
     /**

--- a/Tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\Tests\Unit\DependencyInjection;
 
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
@@ -149,6 +150,9 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
 
         $this->assertMatcherCreated($container, array('_route' => 'my_route'));
         $this->assertListenerHasRule($container, 'fos_http_cache.event_listener.invalidation');
+        
+        // Test for runtime errors
+        $container->compile();
     }
 
     public function testConfigLoadCacheControl()
@@ -282,9 +286,17 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
 
     protected function createContainer()
     {
-        return new ContainerBuilder(new ParameterBag(array(
-            'kernel.debug'       => false,
-        )));
+        $container = new ContainerBuilder(
+            new ParameterBag(array('kernel.debug' => false,))
+        );
+        
+        // The cache_manager service depends on the router service
+        $container->setDefinition(
+            'router',
+            new Definition('\Symfony\Component\Routing\Router')
+        );
+        
+        return $container;
     }
 
     protected function getBaseConfig()


### PR DESCRIPTION
Fix #193.

These services where previously defined in `cache_control_listener.xml`. That file, however, was not loaded e.g. when only invalidation (and no cache control) rules were defined. This PR always load the `request_matcher` and `rule_matcher`, so they can be used in `cache_control`, `invalidation` and/or `tags`.