### PR TITLE
Fixed tagging basic configuration example

### DIFF
--- a/Resources/doc/features/tagging.rst
+++ b/Resources/doc/features/tagging.rst
@@ -24,9 +24,8 @@ Then enable tagging in your application configuration:
 .. code-block:: yaml
 
     fos_http_cache:
-      cache_manager:
         tags:
-          enabled: true
+            enabled: true
 
 For more information, see :doc:`/reference/configuration/tags`.
 


### PR DESCRIPTION
Tags are not updatable under `cache_manager` config, but [directly under root node](https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/master/DependencyInjection/Configuration.php#L65-L75).

[Reference doc](http://foshttpcachebundle.readthedocs.org/en/stable/reference/configuration/tags.html) seems correct though.

Tracked on [eZ community forum](http://share.ez.no/forums/ez-publish-5-platform/fos-http-bundle-and-tagging) :wink: