### PR TITLE
Do not vary response when user identifier and hash are not present in request

### DIFF
--- a/EventListener/UserContextSubscriber.php
+++ b/EventListener/UserContextSubscriber.php
@@ -132,7 +132,7 @@ class UserContextSubscriber implements EventSubscriberInterface
             }
         } else {
             foreach ($this->userIdentifierHeaders as $header) {
-                if (!in_array($header, $vary)) {
+                if ($event->getRequest()->headers->has($header) && !in_array($header, $vary)) {
                     $vary[] = $header;
                 }
             }

--- a/Tests/Unit/EventListener/UserContextSubscriberTest.php
+++ b/Tests/Unit/EventListener/UserContextSubscriberTest.php
@@ -156,6 +156,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
     {
         $request = new Request();
         $request->setMethod('HEAD');
+        $request->headers->set('X-SessionId', 'session');
 
         $requestMatcher = $this->getRequestMatcher($request, false);
         $hashGenerator = \Mockery::mock('\FOS\HttpCache\UserContext\HashGenerator');
@@ -166,6 +167,24 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
         $userContextSubscriber->onKernelResponse($event);
 
         $this->assertEquals('X-SessionId', $event->getResponse()->headers->get('Vary'));
+    }
+
+    /**
+     * If no hash in the request and no user identifier do not set any more vary (anonymous)
+     */
+    public function testOnKernelResponseAnonymousNoVary()
+    {
+        $request = new Request();
+
+        $requestMatcher = $this->getRequestMatcher($request, false);
+        $hashGenerator = \Mockery::mock('\FOS\HttpCache\UserContext\HashGenerator');
+
+        $userContextSubscriber = new UserContextSubscriber($requestMatcher, $hashGenerator, array('X-SessionId'), 'X-Hash');
+        $event = $this->getKernelResponseEvent($request);
+
+        $userContextSubscriber->onKernelResponse($event);
+
+        $this->assertNull($event->getResponse()->headers->get('Vary'));
     }
 
     protected function getKernelRequestEvent(Request $request, $type = HttpKernelInterface::MASTER_REQUEST)


### PR DESCRIPTION
This fix intend to allow user without session to have cache (but they will all have the same cache as there is no way to distinguish them)

Actually it's sending Cookie and Authorization by default even if we don't have this headers in the request which is not well supported by varnish 4