### PR TITLE
adjust example for user context hash url 

### DIFF
--- a/Resources/doc/reference/configuration/user-context.rst
+++ b/Resources/doc/reference/configuration/user-context.rst
@@ -33,7 +33,7 @@ triggered:
 
     # app/config/routing.yml
     user_context_hash:
-        path: /user-context-hash
+        path: /_fos_user_context_hash
 
 .. important::
 


### PR DESCRIPTION
to be consistent with FOSHttpCache examples and Symfony HttpCache plugins

fix #189

luckily, the URL only occurs in the documentation, not in actual code. the context listener listens only looks for the accept header and matches every url.