### PR TITLE
Better Symfony 2.7/3.0 compatibility

### DIFF
--- a/DependencyInjection/Compiler/SecurityContextPass.php
+++ b/DependencyInjection/Compiler/SecurityContextPass.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCacheBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCacheBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Reference;
+
+/**
+ * In Symfony < 2.6, replace the new security.token_storage service with the  
+ * deprecated security.context service. 
+ */
+class SecurityContextPass implements CompilerPassInterface
+{
+    const ROLE_PROVIDER_SERVICE = 'fos_http_cache.user_context.role_provider';
+    
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->has(self::ROLE_PROVIDER_SERVICE)) {
+            return;
+        }
+        
+        if (!$container->has('security.token_storage')) {
+            $definition = $container->getDefinition(self::ROLE_PROVIDER_SERVICE);
+            $definition->replaceArgument(0, new Reference('security.context'));
+        }
+    }
+}

--- a/FOSHttpCacheBundle.php
+++ b/FOSHttpCacheBundle.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCacheBundle;
 
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\LoggerPass;
+use FOS\HttpCacheBundle\DependencyInjection\Compiler\SecurityContextPass;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\TagSubscriberPass;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -25,6 +26,7 @@ class FOSHttpCacheBundle extends Bundle
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new LoggerPass());
+        $container->addCompilerPass(new SecurityContextPass());
         $container->addCompilerPass(new TagSubscriberPass());
         $container->addCompilerPass(new HashGeneratorPass());
     }

--- a/Resources/config/user_context.xml
+++ b/Resources/config/user_context.xml
@@ -31,7 +31,7 @@
         </service>
 
         <service id="fos_http_cache.user_context.role_provider" class="%fos_http_cache.user_context.role_provider.class%" abstract="true">
-            <argument type="service" id="security.context" on-invalid="ignore" />
+            <argument type="service" id="security.token_storage" on-invalid="ignore" />
         </service>
 
         <service id="fos_http_cache.user_context.logout_handler" class="%fos_http_cache.user_context.logout_handler.class%">

--- a/Tests/Functional/Fixtures/app/config/config.yml
+++ b/Tests/Functional/Fixtures/app/config/config.yml
@@ -5,6 +5,10 @@ framework:
   test: ~
   session:
     storage_id:  session.test_storage
+  # We need to specify templating because of a bug in Symfony: 
+  # see https://github.com/symfony/symfony/issues/13710
+  templating: 
+    engines: ['php']
 
 fos_http_cache:
   cache_control:

--- a/Tests/Unit/UserContext/RoleProviderTest.php
+++ b/Tests/Unit/UserContext/RoleProviderTest.php
@@ -22,8 +22,8 @@ class RoleProviderTest extends \PHPUnit_Framework_TestCase
         $roles = array(new Role('ROLE_USER'));
 
         $token           = \Mockery::mock('Symfony\Component\Security\Core\Authentication\Token\TokenInterface');
-        $securityContext = \Mockery::mock('\Symfony\Component\Security\Core\SecurityContext');
-
+        
+        $securityContext = $this->getTokenStorageMock();
         $securityContext->shouldReceive('getToken')->andReturn($token);
         $token->shouldReceive('getRoles')->andReturn($roles);
 
@@ -39,8 +39,7 @@ class RoleProviderTest extends \PHPUnit_Framework_TestCase
 
     public function testProviderWithoutToken()
     {
-        $securityContext = \Mockery::mock('\Symfony\Component\Security\Core\SecurityContext');
-
+        $securityContext = $this->getTokenStorageMock();
         $securityContext->shouldReceive('getToken')->andReturn(null);
 
         $userContext = new UserContext();
@@ -58,5 +57,16 @@ class RoleProviderTest extends \PHPUnit_Framework_TestCase
     {
         $roleProvider = new RoleProvider();
         $roleProvider->updateUserContext(new UserContext());
+    }
+    
+    private function getTokenStorageMock()
+    {
+        if (interface_exists('\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface')) {
+            // Symfony >= 2.6
+            return \Mockery::mock('\Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface');
+        }
+        
+        // Symfony < 2.6 compatibility
+        return \Mockery::mock('\Symfony\Component\Security\Core\SecurityContext');
     }
 }

--- a/UserContext/RoleProvider.php
+++ b/UserContext/RoleProvider.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCacheBundle\UserContext;
 use FOS\HttpCache\UserContext\ContextProviderInterface;
 use FOS\HttpCache\UserContext\UserContext;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
+use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Role\RoleInterface;
 use Symfony\Component\Security\Core\SecurityContextInterface;
 
@@ -34,10 +35,19 @@ class RoleProvider implements ContextProviderInterface
      * firewall. It is however not valid to call updateUserContext when not in
      * a firewall context.
      *
-     * @param SecurityContextInterface|null $context
+     * @param SecurityContextInterface|TokenStorageInterface $context
      */
-    public function __construct(SecurityContextInterface $context = null)
+    public function __construct($context = null)
     {
+        if ($context
+            && !$context instanceof SecurityContextInterface
+            && !$context instanceof TokenStorageInterface
+        ) {
+            throw new \InvalidArgumentException(
+                'Context must implement either TokenStorageInterface or SecurityContextInterface'
+            );
+        }
+        
         $this->context = $context;
     }
 


### PR DESCRIPTION
Adding forwards compatibility for Symfony 2.7/3.0. This makes sense for users already switching over from (deprecated) `TokenStorage` to `SecurityContext` in their applications. This reduces deprecation warnings in our tests. We still need some changes in the bundle config to dynamically inject the token storage instead of the security context service. 