### PR TITLE
allow to configure custom proxy client

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -54,12 +54,15 @@ class Configuration implements ConfigurationInterface
             ->validate()
                 ->ifTrue(function ($v) {return $v['cache_manager']['enabled'] && !isset($v['proxy_client']);})
                 ->then(function ($v) {
+                    if (!empty($v['cache_manager']['proxy_client'])) {
+                        return $v;
+                    }
                     if ('auto' === $v['cache_manager']['enabled']) {
                         $v['cache_manager']['enabled'] = false;
 
                         return $v;
                     }
-                    throw new InvalidConfigurationException('You need to configure a proxy_client to use the cache_manager.');
+                    throw new InvalidConfigurationException('You need to configure a proxy_client or specify a custom_proxy_client to use the cache_manager.');
                 })
             ->end()
             ->validate()
@@ -450,6 +453,9 @@ class Configuration implements ConfigurationInterface
                             ->values(array(true, false, 'auto'))
                             ->defaultValue('auto')
                             ->info('Allows to disable the invalidation manager. Enabled by default if you configure a proxy client.')
+                        ->end()
+                        ->scalarNode('custom_proxy_client')
+                            ->info('Service name of a custom proxy client to use. If you configure a proxy client, that client will be used by default.')
                         ->end()
                         ->enumNode('generate_url_type')
                             ->values(array(

--- a/Resources/doc/reference/configuration/cache-manager.rst
+++ b/Resources/doc/reference/configuration/cache-manager.rst
@@ -2,7 +2,8 @@ cache_manager
 =============
 
 The cache manager is the primary interface to invalidate caches. It is enabled
-by default if a :doc:`Proxy Client <proxy-client>` is configured.
+by default if a :doc:`Proxy Client <proxy-client>` is configured or when you
+specify the ``custom_proxy_client`` field.
 
 .. code-block:: yaml
 
@@ -10,6 +11,7 @@ by default if a :doc:`Proxy Client <proxy-client>` is configured.
     fos_http_cache:
         cache_manager:
             enabled: true
+            custom_proxy_client: ~
             generate_url_type: true
 
 ``enabled``
@@ -19,6 +21,21 @@ by default if a :doc:`Proxy Client <proxy-client>` is configured.
 
 Whether the cache manager service should be enabled. By default, it is enabled
 if a proxy client is configured. It can not be enabled without a proxy client.
+
+``custom_proxy_client``
+-----------------------
+
+**type**: ``string``
+
+Instead of configuring a :doc:`Proxy Client <proxy-client>`, you can define
+your own service that implements ``FOS\HttpCache\ProxyClientInterface``.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    fos_http_cache:
+        cache_manager:
+            custom_proxy_client: acme.caching.proxy_client
 
 ``generate_url_type``
 ---------------------

--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -1,11 +1,16 @@
 proxy_client
 ============
 
-The proxy client sends invalidation requests to your caching proxy. It must be
-configured for the :doc:`Cache Manager </reference/cache-manager>` to work,
-which wraps the proxy client and is the usual entry point for application
-interaction with the caching proxy. The proxy client is also available as a
-service (``fos_http_cache.proxy_client``) that you can use directly.
+The proxy client sends invalidation requests to your caching proxy. The
+:doc:`Cache Manager </reference/cache-manager>` wraps the proxy client and is
+the usual entry point for application interaction with the caching proxy.
+
+You need to configure a client or define your own service for the cache manager
+to work.
+
+The proxy client is also directly available as a service
+(``fos_http_cache.proxy_client.default`` and ``fos_http_cache.proxy_client.varnish``
+or ``fos_http_cache.proxy_client.nginx``) that you can use directly.
 
 varnish
 -------

--- a/Tests/Resources/Fixtures/config/full.php
+++ b/Tests/Resources/Fixtures/config/full.php
@@ -45,6 +45,7 @@ $container->loadFromExtension('fos_http_cache', array(
 
     'cache_manager' => array(
         'enabled' => true,
+        'custom_proxy_client' => 'acme.proxy_client',
     ),
     'tags' => array(
         'header' => 'FOS-Tags',

--- a/Tests/Resources/Fixtures/config/full.xml
+++ b/Tests/Resources/Fixtures/config/full.xml
@@ -43,7 +43,7 @@
             </varnish>
         </proxy-client>
 
-        <cache-manager enabled="true"/>
+        <cache-manager enabled="true" custom-proxy-client="acme.proxy_client"/>
 
         <tags header="FOS-Tags">
             <rule>

--- a/Tests/Resources/Fixtures/config/full.yml
+++ b/Tests/Resources/Fixtures/config/full.yml
@@ -44,6 +44,7 @@ fos_http_cache:
 
     cache_manager:
         enabled: true
+        custom_proxy_client: acme.proxy_client
 
     tags:
         header: FOS-Tags

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -93,6 +93,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             ),
             'cache_manager' => array(
                 'enabled' => true,
+                'custom_proxy_client' => 'acme.proxy_client',
                 'generate_url_type' => 'auto',
             ),
             'tags' => array(


### PR DESCRIPTION
fix #186

This does not handle the test case section, but then i don't think we need to care about that. The test case would need to know about the caching proxy implementation anyways.