### PR TITLE
fix DI for tag.enabled=auto and add configuration tests

### DIFF
--- a/Tests/Resources/Fixtures/config/symfony.php
+++ b/Tests/Resources/Fixtures/config/symfony.php
@@ -1,0 +1,11 @@
+<?php
+
+$container->loadFromExtension('fos_http_cache', array(
+    'proxy_client' => array(
+        'symfony' => array(
+            'servers' => array('22.22.22.22'),
+            'base_url' => '/test',
+            'guzzle_client' => 'acme.guzzle.symfony',
+        ),
+    ),
+));

--- a/Tests/Resources/Fixtures/config/symfony.xml
+++ b/Tests/Resources/Fixtures/config/symfony.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services">
+
+    <config xmlns="http://example.org/schema/dic/fos_http_cache">
+        <proxy-client>
+            <symfony base-url="/test" guzzle-client="acme.guzzle.symfony">
+                <server>22.22.22.22</server>
+            </symfony>
+        </proxy-client>
+
+    </config>
+</container>

--- a/Tests/Resources/Fixtures/config/symfony.yml
+++ b/Tests/Resources/Fixtures/config/symfony.yml
@@ -1,0 +1,7 @@
+fos_http_cache:
+
+    proxy_client:
+        symfony:
+            servers: 22.22.22.22
+            base_url: /test
+            guzzle_client: acme.guzzle.symfony

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -214,6 +214,35 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         }
     }
 
+    public function testSupportsSymfony()
+    {
+        $expectedConfiguration = $this->getEmptyConfig();
+        $expectedConfiguration['proxy_client'] = array(
+            'symfony' => array(
+                'servers' => array('22.22.22.22'),
+                'base_url' => '/test',
+                'guzzle_client' => 'acme.guzzle.symfony',
+            ),
+        );
+        $expectedConfiguration['cache_manager']['enabled'] = 'auto';
+        $expectedConfiguration['cache_manager']['generate_url_type'] = 'auto';
+        $expectedConfiguration['tags']['enabled'] = 'auto';
+        $expectedConfiguration['invalidation']['enabled'] = 'auto';
+        $expectedConfiguration['user_context']['logout_handler']['enabled'] = 'auto';
+
+        $formats = array_map(function ($path) {
+            return __DIR__.'/../../Resources/Fixtures/'.$path;
+        }, array(
+            'config/symfony.yml',
+            'config/symfony.xml',
+            'config/symfony.php',
+        ));
+
+        foreach ($formats as $format) {
+            $this->assertProcessedConfigurationEquals($expectedConfiguration, array($format));
+        }
+    }
+
     public function testSplitOptions()
     {
         $expectedConfiguration = $this->getEmptyConfig();


### PR DESCRIPTION
the default `tags.enabled: auto` was ignored and treated as `true` but no validation done whether this will actually work.

this change fixes the problem. 