### PR TITLE
Fix invalidation not being triggered for some status codes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.3.2
+-----
+
+* Fixed some status codes (such as 204 and 302) not triggering invalidation.
+
 1.3.1
 -----
 

--- a/EventListener/InvalidationSubscriber.php
+++ b/EventListener/InvalidationSubscriber.php
@@ -89,7 +89,9 @@ class InvalidationSubscriber extends AbstractRuleSubscriber implements EventSubs
         $response = $event->getResponse();
 
         // Don't invalidate any caches if the request was unsuccessful
-        if ($response->isSuccessful()) {
+        if ($response->getStatusCode() >= 200
+            && $response->getStatusCode() < 400
+        ) {
             $this->handleInvalidation($request, $response);
         }
 
@@ -144,7 +146,8 @@ class InvalidationSubscriber extends AbstractRuleSubscriber implements EventSubs
     /**
      * Handle the invalidation annotations and configured invalidators.
      *
-     * @param Request $request
+     * @param Request  $request
+     * @param Response $response
      */
     private function handleInvalidation(Request $request, Response $response)
     {

--- a/Http/RuleMatcher.php
+++ b/Http/RuleMatcher.php
@@ -69,7 +69,7 @@ class RuleMatcher implements RuleMatcherInterface
              * headers are already set. As we are about to set them, that would
              * always return false.
              */
-            $status = array(200, 203, 300, 301, 302, 404, 410);
+            $status = array(200, 203, 204, 300, 301, 302, 404, 410);
             if (!empty($this->criteria['additional_cacheable_status'])) {
                 $status = array_merge($status, $this->criteria['additional_cacheable_status']);
             }

--- a/Tests/Functional/EventListener/InvalidationSubscriberTest.php
+++ b/Tests/Functional/EventListener/InvalidationSubscriberTest.php
@@ -33,7 +33,10 @@ class InvalidationSubscriberTest extends WebTestCase
         $client->request('POST', '/invalidate/route/42');
     }
 
-    public function testInvalidatePath()
+    /**
+     * @dataProvider getStatusCodesThatTriggerInvalidation
+     */
+    public function testInvalidatePath($statusCode)
     {
         $client = static::createClient();
 
@@ -43,10 +46,13 @@ class InvalidationSubscriberTest extends WebTestCase
         )
             ->shouldReceive('supports')->andReturn(true)
             ->shouldReceive('invalidatePath')->once()->with('/cached')
+            ->shouldReceive('invalidatePath')->once()->with(
+                sprintf('/invalidate/path/%s', $statusCode)
+            )
             ->shouldReceive('flush')->once()
         ;
 
-        $client->request('POST', '/invalidate/path');
+        $client->request('POST', sprintf('/invalidate/path/%s', $statusCode));
     }
 
     public function testErrorIsNotInvalidated()
@@ -63,6 +69,11 @@ class InvalidationSubscriberTest extends WebTestCase
         ;
 
         $client->request('POST', '/invalidate/error');
+    }
+
+    public function getStatusCodesThatTriggerInvalidation()
+    {
+        return array(array(200), array(204), array(302));
     }
 
     protected function tearDown()

--- a/Tests/Functional/Fixtures/Controller/InvalidationController.php
+++ b/Tests/Functional/Fixtures/Controller/InvalidationController.php
@@ -31,9 +31,9 @@ class InvalidationController extends Controller
     /**
      * @InvalidatePath("/cached")
      */
-    public function otherAction()
+    public function otherAction($statusCode)
     {
-        return new Response('Done.');
+        return new Response('Done.', $statusCode);
     }
 
     /**

--- a/Tests/Functional/Fixtures/app/config/config.yml
+++ b/Tests/Functional/Fixtures/app/config/config.yml
@@ -20,6 +20,13 @@ fos_http_cache:
     varnish:
       servers: 127.0.0.1
       base_url: localhost:8080
+  invalidation:
+    rules:
+      -
+        match:
+          path: ^/invalidate/path.*
+        routes:
+          invalidation_path: ~
   tags:
     rules:
       -

--- a/Tests/Functional/Fixtures/app/config/routing.yml
+++ b/Tests/Functional/Fixtures/app/config/routing.yml
@@ -25,7 +25,7 @@ invalidation_route:
   defaults: { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\InvalidationController::itemAction }
 
 invalidation_path:
-  path: /invalidate/path
+  path: /invalidate/path/{statusCode}
   defaults: { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\InvalidationController::otherAction }
 
 invalidation_error:


### PR DESCRIPTION
Fix #224. Invalidation was not triggered when the controller returned a response with status codes such as 204 or 302. A more elaborate solution, which involves creating separate, configurable response matchers (as well as request matchers), as described in #69, should be done in a separate PR.