### PR TITLE
[SymfonyCache] Remove event classes from Symfony's class cache to fix #242

### DIFF
--- a/DependencyInjection/Compiler/RemoveClassesFromCachePass.php
+++ b/DependencyInjection/Compiler/RemoveClassesFromCachePass.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCacheBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCacheBundle\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+/**
+ * Compiler pass to remove some classes from Symfony's class cache to prevent
+ * from redeclaration in early cache lookup phase
+ * (see https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/issues/242).
+ */
+class RemoveClassesFromCachePass implements CompilerPassInterface
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function process(ContainerBuilder $container)
+    {
+        if (!$container->hasParameter('fos_http_cache.invalidation.enabled')) {
+            return;
+        }
+
+        $frameworkExt = $container->getExtension('framework');
+        $classes = $frameworkExt->getClassesToCompile();
+
+        // remove classes
+        $classesToRemove = array(
+            'Symfony\\Component\\EventDispatcher\\Event',
+            'Symfony\\Component\\HttpKernel\\Event\\KernelEvent',
+            'Symfony\\Component\\HttpKernel\\Event\\FilterControllerEvent',
+            'Symfony\\Component\\HttpKernel\\Event\\FilterResponseEvent',
+            'Symfony\\Component\\HttpKernel\\Event\\GetResponseEvent',
+            'Symfony\\Component\\HttpKernel\\Event\\GetResponseForControllerResultEvent',
+            'Symfony\\Component\\HttpKernel\\Event\\GetResponseForExceptionEvent',
+        );
+        foreach ($classesToRemove as $className) {
+            $index = array_search($className, $classes);
+            array_splice($classes, $index, 1);
+        }
+
+        // overwrite array for class cache via reflection (no other way)
+        $reflClass = new \ReflectionClass('Symfony\\Component\\HttpKernel\\DependencyInjection\\Extension');
+        $reflProp = $reflClass->getProperty('classes');
+        $reflProp->setAccessible(true);
+        $reflProp->setValue($frameworkExt, $classes);

--- a/DependencyInjection/Compiler/RemoveClassesFromCachePass.php
+++ b/DependencyInjection/Compiler/RemoveClassesFromCachePass.php
@@ -53,3 +53,5 @@ class RemoveClassesFromCachePass implements CompilerPassInterface
         $reflProp = $reflClass->getProperty('classes');
         $reflProp->setAccessible(true);
         $reflProp->setValue($frameworkExt, $classes);
+    }
+}

--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -100,6 +100,7 @@ class FOSHttpCacheExtension extends Extension
             if (!empty($config['invalidation']['rules'])) {
                 $this->loadInvalidatorRules($container, $config['invalidation']['rules']);
             }
+            $container->setParameter($this->getAlias().'.invalidation.enabled', true);
         }
 
         if ($config['user_context']['enabled']) {

--- a/FOSHttpCacheBundle.php
+++ b/FOSHttpCacheBundle.php
@@ -15,6 +15,7 @@ use FOS\HttpCacheBundle\DependencyInjection\Compiler\LoggerPass;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\SecurityContextPass;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\TagSubscriberPass;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
+use FOS\HttpCacheBundle\DependencyInjection\Compiler\RemoveClassesFromCachePass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
@@ -29,5 +30,6 @@ class FOSHttpCacheBundle extends Bundle
         $container->addCompilerPass(new SecurityContextPass());
         $container->addCompilerPass(new TagSubscriberPass());
         $container->addCompilerPass(new HashGeneratorPass());
+        $container->addCompilerPass(new RemoveClassesFromCachePass());
     }
 }


### PR DESCRIPTION
Symfony's class cache (*cache/<env>/classes.php*) compiles classes that are loaded on each request.

But when using `EventDispatchingHttpCache` there may occure errors, when using Symfony's HttpCache, because EventDispatchingHttpCache loads some classes (`Symfony\Component\EventDispatcher\Event`) individually via autoload and later when the HttpKernel is bootet in a subrequest and the class cache is loaded, PHP runs into a fatal error because of redeclaration of the class `Symfony\Component\EventDispatcher\Event` (as you can see in #242).

To fix this issue I have added an compiler pass to remove the mentioned classes from the cache class map before the cache is built. This only happens if cache invalidation is used (as it only happens in that case, afaik).

If there are any objections/annotations to this PR, please let me know.