### PR TITLE
Use decodeURIComponent to decode cookie before parsing it

### DIFF
--- a/Resources/doc/features/helpers/flash-message.rst
+++ b/Resources/doc/features/helpers/flash-message.rst
@@ -49,7 +49,7 @@ to only show the flash message once. Something along these lines:
             return;
         }
 
-        var flashes = JSON.parse(cookie);
+        var flashes = JSON.parse(decodeURIComponent(cookie));
 
         // show flashes in your DOM...
 


### PR DESCRIPTION
When we use this function as it is, we get a javascript error saying:

```
SyntaxError: JSON.parse: unexpected character at line 1 column 1 of the JSON data
	var a=JSON.parse(b);console.log(a);...
```
In the server side, json_encode encrypt the cookie in HTTP, so to parse the cookie we should decrypt that can by using decodeURIComponent javascript function.