### PR TITLE
drop php 5.3 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: php
 
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3",
+        "php": ">=5.4.0",
         "friendsofsymfony/http-cache": "~1.4",
         "symfony/framework-bundle": "~2.3"
     },
@@ -48,7 +48,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.3.x-dev"
+            "dev-master": "2.0.x-dev"
         }
     }
 }


### PR DESCRIPTION
PHP 5.3 is past its end of live date. 

And builds fail with out of memory problems...
https://travis-ci.org/FriendsOfSymfony/FOSHttpCacheBundle/jobs/91344571