### PR TITLE
Fix dependency on a non-existent service "security.context"

### DIFF
--- a/DependencyInjection/Compiler/SecurityContextPass.php
+++ b/DependencyInjection/Compiler/SecurityContextPass.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\Reference;
 class SecurityContextPass implements CompilerPassInterface
 {
     const ROLE_PROVIDER_SERVICE = 'fos_http_cache.user_context.role_provider';
-    
+
     /**
      * {@inheritdoc}
      */
@@ -31,8 +31,8 @@ class SecurityContextPass implements CompilerPassInterface
         if (!$container->has(self::ROLE_PROVIDER_SERVICE)) {
             return;
         }
-        
-        if (!$container->has('security.token_storage')) {
+
+        if (!$container->has('security.token_storage') && $container->has('security.context')) {
             $definition = $container->getDefinition(self::ROLE_PROVIDER_SERVICE);
             $definition->replaceArgument(0, new Reference('security.context'));
         }


### PR DESCRIPTION
The security part is optional in the role provider class, which is why `security.token_storage` is also defined with `on-invalid=ignore`.
As we have security disabled in dev env, neither security.token_storage nor security.context exists, but it still tries to replace the dependency and loses on-invalid=ignore. Then it was complaining, that the service is missing.