### PR TITLE
Removed over-zealous configuration checks

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -79,10 +79,6 @@ class Configuration implements ConfigurationInterface
                 })
             ->end()
             ->validate()
-                ->ifTrue(function ($v) {return $v['tags']['rules'] && !$v['tags']['enabled'];})
-                ->thenInvalid('You need to enable the cache_manager and tags to use rules.')
-            ->end()
-            ->validate()
                 ->ifTrue(function ($v) {return $v['invalidation']['enabled'] && !$v['cache_manager']['enabled'];})
                 ->then(function ($v) {
                     if ('auto' === $v['invalidation']['enabled']) {
@@ -92,10 +88,6 @@ class Configuration implements ConfigurationInterface
                     }
                     throw new InvalidConfigurationException('You need to configure a proxy_client to get the cache_manager needed for invalidation handling.');
                 })
-            ->end()
-            ->validate()
-                ->ifTrue(function ($v) {return $v['invalidation']['rules'] && !$v['invalidation']['enabled'];})
-                ->thenInvalid('You need to enable the cache_manager and invalidation to use rules.')
             ->end()
             ->validate()
                 ->ifTrue(function ($v) {

--- a/Tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/Tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -388,46 +388,6 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         }
     }
 
-    public function testTagRulesNotEnabled()
-    {
-        $formats = array_map(function ($path) {
-            return __DIR__.'/../../Resources/Fixtures/'.$path;
-        }, array(
-            'config/tags_rules.yml',
-            'config/tags_rules.xml',
-            'config/tags_rules.php',
-        ));
-
-        foreach ($formats as $format) {
-            try {
-                $this->assertProcessedConfigurationEquals(array(), array($format));
-                $this->fail('No exception thrown on invalid configuration');
-            } catch (InvalidConfigurationException $e) {
-                $this->assertContains('need to enable the cache_manager and tags to use rules', $e->getMessage());
-            }
-        }
-    }
-
-    public function testInvalidationRulesNotEnabled()
-    {
-        $formats = array_map(function ($path) {
-            return __DIR__.'/../../Resources/Fixtures/'.$path;
-        }, array(
-            'config/invalidation_rules.yml',
-            'config/invalidation_rules.xml',
-            'config/invalidation_rules.php',
-        ));
-
-        foreach ($formats as $format) {
-            try {
-                $this->assertProcessedConfigurationEquals(array(), array($format));
-                $this->fail('No exception thrown on invalid configuration');
-            } catch (InvalidConfigurationException $e) {
-                $this->assertContains('need to enable the cache_manager and invalidation to use rules', $e->getMessage());
-            }
-        }
-    }
-
     public function testInvalidDate()
     {
         $formats = array_map(function ($path) {


### PR DESCRIPTION
With these checks removed you can now specify `enabled: false` on invalidation or tagging configuration sections even if you have previously defined some rules for that section.