### PR TITLE
prevent allowing cache if hash has changed

### DIFF
--- a/EventListener/UserContextSubscriber.php
+++ b/EventListener/UserContextSubscriber.php
@@ -131,7 +131,8 @@ class UserContextSubscriber implements EventSubscriberInterface
 
         // hash has changed, session has most certainly changed, prevent setting incorrect cache
         if ($request->attributes->has($this->hashHeader) && $request->attributes->get($this->hashHeader) !== $request->headers->get($this->hashHeader)) {
-            $response->setPrivate();
+            $response->setClientTtl(0);
+            $response->headers->addCacheControlDirective('no-cache');
 
             return;
         }

--- a/EventListener/UserContextSubscriber.php
+++ b/EventListener/UserContextSubscriber.php
@@ -88,9 +88,10 @@ class UserContextSubscriber implements EventSubscriberInterface
         }
 
         $hash = $this->hashGenerator->generateHash();
-        $event->getRequest()->attributes->set($this->hashHeader, $hash);
 
         if (!$this->requestMatcher->matches($event->getRequest())) {
+            $event->getRequest()->attributes->set($this->hashHeader, $hash);
+
             return;
         }
 
@@ -129,7 +130,7 @@ class UserContextSubscriber implements EventSubscriberInterface
         $request = $event->getRequest();
 
         // hash has changed, session has most certainly changed, prevent setting incorrect cache
-        if ($request->attributes->get($this->hashHeader) !== $request->headers->get($this->hashHeader)) {
+        if ($request->attributes->has($this->hashHeader) && $request->attributes->get($this->hashHeader) !== $request->headers->get($this->hashHeader)) {
             $response->setPrivate();
 
             return;


### PR DESCRIPTION
I heavily use role provider user context hash  with a ttl of 900s.

A session deconnexion happening while the hash is in cache trigger a situation where you set an anonymous data for an authenticated hash. In this situation there is no breach of security (yeah) but it's definitively a bug.

Proposed solution is to generate a hash at each request and prevent setting cache if hash are not equivalent (ie: roles or situation has changed).

Tests to be added, but I want to start the discussion.