### PR TITLE
check sanity of user context hash, if not, prevent setting any cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,19 @@
 Changelog
 =========
 
+
+1.3.7
+-----
+
+* Add a sanity check on UserContextHash to avoid invalid content being cached
+  (example: anonymous cache set for authenticated user). This scenario occures
+  when the UserContextHash is cached by Varnish via 
+  `fos_http_cache.user_context.hash_cache_ttl` > 0 and the session is lost via 
+  garbage collector. The data given is the anonymous one despite having a hash 
+  for authenticated, all authenticated users will then have the anonymous version.
+  Same problem could occurs with users having is role changed or anything else
+  that can modify the hash.
+
 1.3.2
 -----
 

--- a/Tests/Unit/EventListener/UserContextSubscriberTest.php
+++ b/Tests/Unit/EventListener/UserContextSubscriberTest.php
@@ -104,6 +104,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $requestMatcher = $this->getRequestMatcher($request, false);
         $hashGenerator = \Mockery::mock('\FOS\HttpCache\UserContext\HashGenerator');
+        $hashGenerator->shouldReceive('generateHash')->andReturn('hash');
 
         $userContextSubscriber = new UserContextSubscriber($requestMatcher, $hashGenerator, array('X-SessionId'), 'X-Hash');
         $event = $this->getKernelRequestEvent($request);
@@ -166,6 +167,67 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
         $userContextSubscriber->onKernelResponse($event);
 
         $this->assertEquals('X-SessionId', $event->getResponse()->headers->get('Vary'));
+    }
+
+    /**
+     * If there is no hash in the request, vary on the user identifier.
+     */
+    public function testFullRequestHashOk()
+    {
+        $request = new Request();
+        $request->setMethod('GET');
+        $request->headers->set('X-Hash', 'hash');
+
+        $requestMatcher = $this->getRequestMatcher($request, false);
+        $hashGenerator = \Mockery::mock('\FOS\HttpCache\UserContext\HashGenerator');
+        $hashGenerator->shouldReceive('generateHash')->andReturn('hash');
+
+        // onKernelRequest
+        $userContextSubscriber = new UserContextSubscriber($requestMatcher, $hashGenerator, array('X-SessionId'), 'X-Hash');
+        $event = $this->getKernelRequestEvent($request);
+
+        $userContextSubscriber->onKernelRequest($event);
+
+        $response = $event->getResponse();
+
+        $this->assertNull($response);
+
+        // onKernelResponse
+        $event = $this->getKernelResponseEvent($request);
+        $userContextSubscriber->onKernelResponse($event);
+
+        $this->assertContains('X-Hash', $event->getResponse()->headers->get('Vary'));
+    }
+
+    /**
+     * If there is no hash in the requests but session changed, prevent setting bad cache
+     */
+    public function testFullRequestHashChanged()
+    {
+        $request = new Request();
+        $request->setMethod('GET');
+        $request->headers->set('X-Hash', 'hash');
+
+        $requestMatcher = $this->getRequestMatcher($request, false);
+        $hashGenerator = \Mockery::mock('\FOS\HttpCache\UserContext\HashGenerator');
+        $hashGenerator->shouldReceive('generateHash')->andReturn('hash-changed');
+
+        // onKernelRequest
+        $userContextSubscriber = new UserContextSubscriber($requestMatcher, $hashGenerator, array('X-SessionId'), 'X-Hash');
+        $event = $this->getKernelRequestEvent($request);
+
+        $userContextSubscriber->onKernelRequest($event);
+
+        $response = $event->getResponse();
+
+        $this->assertNull($response);
+
+        // onKernelResponse
+        $event = $this->getKernelResponseEvent($request);
+        $userContextSubscriber->onKernelResponse($event);
+
+        $this->assertFalse($event->getResponse()->headers->has('Vary'));
+        $this->assertEquals('max-age=0, no-cache, private', $event->getResponse()->headers->get('Cache-Control'));
     }
 
     protected function getKernelRequestEvent(Request $request, $type = HttpKernelInterface::MASTER_REQUEST)


### PR DESCRIPTION
I heavily use role provider user context hash  with a ttl of 900s.

A session deconnexion happening while the hash is in cache trigger a situation where you set an anonymous data for an authenticated hash. In this situation there is no breach of security (yeah) but it's definitively a bug.

Proposed solution is to generate a hash at each request and prevent setting cache if hash are not equivalent (ie: roles or situation has changed).

Tests to be added, but I want to start the discussion.

See #273 