### PR TITLE
Support for caching OPTIONS HTTP verb

### DIFF
--- a/EventListener/CacheControlSubscriber.php
+++ b/EventListener/CacheControlSubscriber.php
@@ -101,8 +101,15 @@ class CacheControlSubscriber extends AbstractRuleSubscriber implements EventSubs
             $response->headers->set($this->debugHeader, 1, false);
         }
 
+
+        if ($this->skip) {
+            return;
+        }
+
         // do not change cache directives on unsafe requests.
-        if ($this->skip || !$this->isRequestSafe($request)) {
+        if ($request->getMethod() !== 'OPTIONS' &&
+            !$this->isRequestSafe($request)
+        ) {
             return;
         }
 

--- a/Tests/Unit/EventListener/CacheControlSubscriberTest.php
+++ b/Tests/Unit/EventListener/CacheControlSubscriberTest.php
@@ -353,6 +353,38 @@ class CacheControlSubscriberTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * Safe methods should get into the matchRule
+     * @dataProvider getSafeMethods
+     * @param $method
+     */
+    public function testSafeMethodsTriggersMatchRule($method)
+    {
+        $subscriber = $this->getMockBuilder('FOS\HttpCacheBundle\EventListener\CacheControlSubscriber')
+            ->setMethods(array('matchRule'))
+            ->getMock()
+        ;
+        $subscriber->expects($this->once())
+            ->method('matchRule')
+        ;
+        $event = $this->buildEvent($method);
+
+        $subscriber->onKernelResponse($event);
+    }
+
+    /**
+     * Safe Methods data
+     * @return array
+     */
+    public function getSafeMethods()
+    {
+        return array(
+            'testSafeMethod for GET' => array('GET'),
+            'testSafeMethod for HEAD' => array('HEAD'),
+            'testSafeMethod for OPTIONS' => array('OPTIONS'),
+        );
+    }
+
+    /**
      * Build the filter response event with a mock kernel and default request
      * and response objects.
      *


### PR DESCRIPTION
Hello,

I'm was trying to cache an OPTIONS request, it was not registering any kind of header, while debugging I found this:
https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/master/EventListener/CacheControlSubscriber.php#L105

Which leads to:
https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Request.php#L1473

Meaning I can't handle OPTIONS requests.

My approach was to make it safe during the Subscriber event. Reason being, we do not want to change the safe methods on SF core.

I'm not using new array notation since I saw the code was using the old one!

Is this a good way? Please I would like to receive any feedback!
