### PR TITLE
trigger deprecation notices for deprecated code

### DIFF
--- a/CacheManager.php
+++ b/CacheManager.php
@@ -72,6 +72,8 @@ class CacheManager extends CacheInvalidator
      */
     public function tagResponse(Response $response, array $tags, $replace = false)
     {
+        @trigger_error('The '.__METHOD__.' method is deprecated since version 1.2 and will be removed in 2.0. Use the TagHandler instead.', E_USER_DEPRECATED);
+
         if (!$replace && $response->headers->has($this->getTagsHeader())) {
             $header = $response->headers->get($this->getTagsHeader());
             if ('' !== $header) {

--- a/Command/InvalidateTagCommand.php
+++ b/Command/InvalidateTagCommand.php
@@ -54,6 +54,10 @@ class InvalidateTagCommand extends ContainerAwareCommand
                 )
             );
         }
+        if ($tagHandler instanceof CacheManager) {
+            @trigger_error('Passing the CacheManager to '.__CLASS__.' is deprecated since version 1.2 and will be removed in 2.0. Provide the TagHandler instead.', E_USER_DEPRECATED);
+
+        }
         $this->commandName = $commandName;
         $this->tagHandler = $tagHandler;
         parent::__construct();

--- a/HttpCache.php
+++ b/HttpCache.php
@@ -20,6 +20,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+@trigger_error('The '.__NAMESPACE__.'\HttpCache class is deprecated since version 1.2 and will be removed in 2.0. Use FOS\HttpCacheBundle\SymfonyCache\EventDispatchingHttpCache instead.', E_USER_DEPRECATED);
+
 /**
  * Base class for enhanced Symfony reverse proxy based on the symfony FrameworkBundle HttpCache.
  *

--- a/Tests/Unit/CacheManagerTest.php
+++ b/Tests/Unit/CacheManagerTest.php
@@ -80,6 +80,9 @@ class CacheManagerTest extends \PHPUnit_Framework_TestCase
         ;
     }
 
+    /**
+     * @group legacy
+     */
     public function testTagResponse()
     {
         $ban = \Mockery::mock('\FOS\HttpCache\ProxyClient\Invalidation\BanInterface');

--- a/Tests/Unit/HttpCacheTest.php
+++ b/Tests/Unit/HttpCacheTest.php
@@ -16,6 +16,9 @@ use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
+/**
+ * @group legacy
+ */
 class HttpCacheTest extends \PHPUnit_Framework_TestCase
 {
     /**


### PR DESCRIPTION
fix #266

@Tobion am i correct that this should go into the 1.3 branch? we want to delete this things for 2.0 so the deprecations would not really help there. i don't want to build a 1.4 version only for the migration like symfony 2.8 is - too much effort.
also, do you know how to make the deprecations helper not complain about our legacy tests? i tried the `@legacy` annotation on the test cases, but that did not seem help.