### PR TITLE
handle configuration where we only have a custom proxy client and proxies configured

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -507,7 +507,7 @@ class Configuration implements ConfigurationInterface
                             ->info('Allows to disable the invalidation manager. Enabled by default if you configure a proxy client.')
                         ->end()
                         ->scalarNode('custom_proxy_client')
-                            ->info('Service name of a custom proxy client to use. If you configure a proxy client, that client will be used by default.')
+                            ->info('Service name of a custom proxy client to use. With a custom client, generate_url_type defaults to ABSOLUTE_URL and tag support needs to be explicitly enabled. If no custom proxy client is specified, the first proxy client you configured is used.')
                         ->end()
                         ->enumNode('generate_url_type')
                             ->values(array(

--- a/DependencyInjection/FOSHttpCacheExtension.php
+++ b/DependencyInjection/FOSHttpCacheExtension.php
@@ -64,7 +64,7 @@ class FOSHttpCacheExtension extends Extension
         }
 
         if ($config['cache_manager']['enabled']) {
-            if (!empty($config['cache_manager']['custom_proxy_client'])) {
+            if (array_key_exists('custom_proxy_client', $config['cache_manager'])) {
                 // overwrite the previously set alias, if a proxy client was also configured
                 $container->setAlias(
                     $this->getAlias().'.default_proxy_client',
@@ -72,11 +72,15 @@ class FOSHttpCacheExtension extends Extension
                 );
             }
             if ('auto' === $config['cache_manager']['generate_url_type']) {
-                $defaultClient = $this->getDefaultProxyClient($config['proxy_client']);
-                $generateUrlType = empty($config['cache_manager']['custom_proxy_client']) && isset($config['proxy_client'][$defaultClient]['base_url'])
-                    ? UrlGeneratorInterface::ABSOLUTE_PATH
-                    : UrlGeneratorInterface::ABSOLUTE_URL
-                ;
+                if (array_key_exists('custom_proxy_client', $config['cache_manager'])) {
+                    $generateUrlType = UrlGeneratorInterface::ABSOLUTE_URL;
+                } else {
+                    $defaultClient = $this->getDefaultProxyClient($config['proxy_client']);
+                    $generateUrlType = array_key_exists('base_url', $config['proxy_client'][$defaultClient])
+                        ? UrlGeneratorInterface::ABSOLUTE_PATH
+                        : UrlGeneratorInterface::ABSOLUTE_URL
+                    ;
+                }
             } else {
                 $generateUrlType = $config['cache_manager']['generate_url_type'];
             }
@@ -89,7 +93,9 @@ class FOSHttpCacheExtension extends Extension
                 $container,
                 $loader,
                 $config['tags'],
-                $this->getDefaultProxyClient($config['proxy_client'])
+                array_key_exists('proxy_client', $config)
+                    ? $this->getDefaultProxyClient($config['proxy_client'])
+                    : 'custom'
             );
         } else {
             $container->setParameter($this->getAlias().'.compiler_pass.tag_annotations', false);
@@ -313,6 +319,13 @@ class FOSHttpCacheExtension extends Extension
         }
     }
 
+    /**
+     * @param ContainerBuilder $container
+     * @param XmlFileLoader    $loader
+     * @param array            $config    Configuration section for the tags node
+     * @param string           $client    Name of the client used with the cache manager,
+     *                                    "custom" when a custom client is used
+     */
     private function loadCacheTagging(ContainerBuilder $container, XmlFileLoader $loader, array $config, $client)
     {
         if ('auto' === $config['enabled'] && 'varnish' !== $client) {
@@ -320,7 +333,7 @@ class FOSHttpCacheExtension extends Extension
 
             return;
         }
-        if ('varnish' !== $client) {
+        if (!in_array($client, array('varnish', 'custom'))) {
             throw new InvalidConfigurationException(sprintf('You can not enable cache tagging with %s', $client));
         }
 

--- a/Resources/doc/reference/configuration/cache-manager.rst
+++ b/Resources/doc/reference/configuration/cache-manager.rst
@@ -39,13 +39,17 @@ your own service that implements ``FOS\HttpCache\ProxyClientInterface``.
         cache_manager:
             custom_proxy_client: acme.caching.proxy_client
 
+When you specify a custom proxy client, the bundle does not know about the
+capabilities of the client. The ``generate_url_type`` defaults to true and
+:doc:`tag support <tags>` is only active if explicitly enabled.
+
 ``generate_url_type``
 ---------------------
 
-**type**: ``enum`` **options**: ``auto``, ``true``, ``false``, ``relative``, ``network``
+**type**: ``enum`` **Symfony 2 options**: ``auto`` or one of the constants in UrlGeneratorInterface
 
 The ``$referenceType`` to be used when generating URLs in the ``invalidateRoute()``
-and ``refreshRoute()`` calls. True results in absolute URLs including the current domain,
-``false`` generates a path without domain, needing a ``base_url`` to be configured
-on the proxy client. When set to ``auto``, the value is determined based on ``base_url``
-of the default proxy client.
+and ``refreshRoute()`` calls. If you use ``ABSOLUTE_PATH`` to only generate
+paths, you need to configure the ``base_url`` on the proxy client. When set to
+``auto``, the value is determined based on whether ``base_url`` is set on the
+default proxy client.

--- a/Tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/Tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -119,6 +119,25 @@ class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($container->hasDefinition('fos_http_cache.handler.tag_handler'));
     }
 
+    public function testConfigCustomClient()
+    {
+        $container = $this->createContainer();
+        $this->extension->load(array(
+            array(
+                'cache_manager' => array(
+                    'custom_proxy_client' => 'app.cache.client',
+                ),
+            ),
+        ), $container);
+
+        $this->assertFalse($container->hasDefinition('fos_http_cache.proxy_client.varnish'));
+        $this->assertFalse($container->hasDefinition('fos_http_cache.proxy_client.nginx'));
+        $this->assertFalse($container->hasDefinition('fos_http_cache.proxy_client.symfony'));
+        $this->assertTrue($container->hasAlias('fos_http_cache.default_proxy_client'));
+        $this->assertTrue($container->hasDefinition('fos_http_cache.event_listener.invalidation'));
+        $this->assertFalse($container->hasDefinition('fos_http_cache.handler.tag_handler'));
+    }
+
     public function testEmptyConfig()
     {
         $config = array();


### PR DESCRIPTION
without this fix, a config like the following leads to an error during container building:

```
    cache_manager:
        custom_proxy_client: "app.caching.rabbitmq_client"
```

`Undefined index: proxy_client`