### PR TITLE
Symfony 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,9 +43,6 @@ matrix:
         - SYMFONY_VERSION='2.8.*'
     - php: 7.1
       env:
-        - SYMFONY_VERSION='3.0.*'
-    - php: 7.1
-      env:
         - SYMFONY_VERSION='3.1.*'
     - php: 7.1
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,9 @@ matrix:
     - php: 7.1
       env:
         - SYMFONY_VERSION='3.1.*'
+    - php: 7.1
+      env:
+        - SYMFONY_VERSION='3.2.*'
 install:
   - pip install -qr doc/requirements.txt --user
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
     "require": {
         "php": "^5.5.0 || ^7.0.0",
         "friendsofsymfony/http-cache": "2.0.x-dev",
-        "symfony/framework-bundle": "^2.8||^3.0"
+        "symfony/framework-bundle": "^2.8||^3.0",
+        "symfony/http-foundation": "~2.7.20 || ~2.8.13 || ^3.1.6 || ^3.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.5.0 || ^5.0.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^5.5.0 || ^7.0.0",
         "friendsofsymfony/http-cache": "2.0.x-dev",
         "symfony/framework-bundle": "^2.8||^3.0",
-        "symfony/http-foundation": "~2.7.20 || ~2.8.13 || ^3.1.6 || ^3.2.0"
+        "symfony/http-foundation": "~2.8.13 || ^3.1.6 || ^3.2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.5.0 || ^5.0.0",

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php": "^5.5.0 || ^7.0.0",
         "friendsofsymfony/http-cache": "2.0.x-dev",
         "symfony/framework-bundle": "^2.8||^3.0",
-        "symfony/http-foundation": "~2.8.13 || ^3.1.6 || ^3.2.0"
+        "symfony/http-foundation": "~2.8.13 || ^3.1.6"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.5.0 || ^5.0.0",

--- a/src/EventListener/CacheControlListener.php
+++ b/src/EventListener/CacheControlListener.php
@@ -158,7 +158,7 @@ class CacheControlListener extends AbstractRuleListener implements EventSubscrib
             return;
         }
 
-        if ('no-cache' === $response->headers->get('cache-control')) {
+        if (false !== strpos($response->headers->get('Cache-Control'), 'no-cache')) {
             // this single header is set by default. if its the only thing, we override it.
             $response->setCache($directives);
 

--- a/src/EventListener/CacheControlListener.php
+++ b/src/EventListener/CacheControlListener.php
@@ -220,6 +220,6 @@ class CacheControlListener extends AbstractRuleListener implements EventSubscrib
      */
     protected function isRequestSafe(Request $request)
     {
-        return $request->isMethodSafe();
+        return $request->isMethodCacheable();
     }
 }

--- a/src/EventListener/TagListener.php
+++ b/src/EventListener/TagListener.php
@@ -88,7 +88,7 @@ class TagListener extends AbstractRuleListener implements EventSubscriberInterfa
             }
         }
 
-        if ($request->isMethodSafe()) {
+        if ($request->isMethodCacheable()) {
             $this->symfonyResponseTagger->addTags($tags);
             if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
                 // For safe requests (GET and HEAD), set cache tags on response

--- a/tests/Functional/EventListener/CacheControlListenerTest.php
+++ b/tests/Functional/EventListener/CacheControlListenerTest.php
@@ -30,6 +30,7 @@ class CacheControlListenerTest extends WebTestCase
 
         $client->request('GET', '/noncached');
         $response = $client->getResponse();
-        $this->assertEquals('no-cache', $response->headers->get('Cache-Control'));
+        // using contains because Symfony 3.2 add `private` when the cache is not public
+        $this->assertContains('no-cache', $response->headers->get('Cache-Control'));
     }
 }

--- a/tests/Functional/Fixtures/Controller/TagController.php
+++ b/tests/Functional/Fixtures/Controller/TagController.php
@@ -32,7 +32,7 @@ class TagController extends Controller
      */
     public function itemAction(Request $request, $id)
     {
-        if (!$request->isMethodSafe()) {
+        if (!$request->isMethodCacheable()) {
             $this->container->get('fos_http_cache.cache_manager')->invalidateTags(['all-items']);
         }
 


### PR DESCRIPTION
Should replace https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/324

Fix deprecated methods
- Add support for Symfony 3.2
- Fix the default private cache control added by Symfony 3.2
- Use `isMethodCacheable` instead of `isMethodSafe` (because it's deprecated)

I hope the new `symfony/http-foundation` restriction is ok.