### PR TITLE
Use new Request::isMethodCacheable when available 

### DIFF
--- a/EventListener/CacheControlSubscriber.php
+++ b/EventListener/CacheControlSubscriber.php
@@ -220,6 +220,6 @@ class CacheControlSubscriber extends AbstractRuleSubscriber implements EventSubs
      */
     protected function isRequestSafe(Request $request)
     {
-        return $request->isMethodSafe();
+        return method_exists($request, 'isMethodCacheable') ? $request->isMethodCacheable() : $request->isMethodSafe();
     }
 }


### PR DESCRIPTION
Request::isMethodSafe has different semantics and is deprecated for the old use-case.

Replaces #324 for 1.3