### PR TITLE
Add support for Symfony 3.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,6 +64,14 @@ matrix:
       env:
         - SYMFONY_VERSION='3.0.*'
         - FRAMEWORK_EXTRA_VERSION='~3.0'
+    - php: 5.6
+      env:
+        - SYMFONY_VERSION='3.1.*'
+        - FRAMEWORK_EXTRA_VERSION='~3.0'
+    - php: 5.6
+      env:
+        - SYMFONY_VERSION='3.2.*'
+        - FRAMEWORK_EXTRA_VERSION='~3.0'
 
 install:
   - pip install -qr Resources/doc/requirements.txt --user

--- a/EventListener/AbstractRuleSubscriber.php
+++ b/EventListener/AbstractRuleSubscriber.php
@@ -54,4 +54,16 @@ class AbstractRuleSubscriber
 
         return false;
     }
+
+    /**
+     * Decide whether to even look for matching rules with the current request.
+     *
+     * @param Request $request
+     *
+     * @return bool True if the request is safe and headers can be set
+     */
+    protected function isRequestSafe(Request $request)
+    {
+        return method_exists($request, 'isMethodCacheable') ? $request->isMethodCacheable() : $request->isMethodSafe();
+    }
 }

--- a/EventListener/AbstractRuleSubscriber.php
+++ b/EventListener/AbstractRuleSubscriber.php
@@ -62,7 +62,7 @@ class AbstractRuleSubscriber
      *
      * @return bool True if the request is safe and headers can be set
      */
-    protected function isRequestSafe(Request $request)
+    protected function isRequestCacheable(Request $request)
     {
         return method_exists($request, 'isMethodCacheable') ? $request->isMethodCacheable() : $request->isMethodSafe();
     }

--- a/EventListener/CacheControlSubscriber.php
+++ b/EventListener/CacheControlSubscriber.php
@@ -220,6 +220,6 @@ class CacheControlSubscriber extends AbstractRuleSubscriber implements EventSubs
      */
     protected function isRequestSafe(Request $request)
     {
-        return $request->isMethodSafe();
+        return method_exists($request, 'isMethodCacheable') ? $request->isMethodCacheable() : $request->isMethodSafe();
     }
 }

--- a/EventListener/CacheControlSubscriber.php
+++ b/EventListener/CacheControlSubscriber.php
@@ -158,7 +158,7 @@ class CacheControlSubscriber extends AbstractRuleSubscriber implements EventSubs
             return;
         }
 
-        if ('no-cache' === $response->headers->get('cache-control')) {
+        if (false !== strpos($response->headers->get('Cache-Control'), 'no-cache')) {
             // this single header is set by default. if its the only thing, we override it.
             $response->setCache($directives);
 
@@ -209,17 +209,5 @@ class CacheControlSubscriber extends AbstractRuleSubscriber implements EventSubs
                 $response->headers->addCacheControlDirective($option, $controls[$key]);
             }
         }
-    }
-
-    /**
-     * Decide whether to even look for matching rules with the current request.
-     *
-     * @param Request $request
-     *
-     * @return bool True if the request is safe and headers can be set
-     */
-    protected function isRequestSafe(Request $request)
-    {
-        return method_exists($request, 'isMethodCacheable') ? $request->isMethodCacheable() : $request->isMethodSafe();
     }
 }

--- a/EventListener/CacheControlSubscriber.php
+++ b/EventListener/CacheControlSubscriber.php
@@ -102,7 +102,7 @@ class CacheControlSubscriber extends AbstractRuleSubscriber implements EventSubs
         }
 
         // do not change cache directives on unsafe requests.
-        if ($this->skip || !$this->isRequestSafe($request)) {
+        if ($this->skip || !$this->isRequestCacheable($request)) {
             return;
         }
 

--- a/EventListener/TagSubscriber.php
+++ b/EventListener/TagSubscriber.php
@@ -79,7 +79,7 @@ class TagSubscriber extends AbstractRuleSubscriber implements EventSubscriberInt
             }
         }
 
-        if ($this->isRequestSafe($request)) {
+        if ($this->isRequestCacheable($request)) {
             $this->tagHandler->addTags($tags);
             if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
                 // For safe requests (GET and HEAD), set cache tags on response

--- a/EventListener/TagSubscriber.php
+++ b/EventListener/TagSubscriber.php
@@ -79,7 +79,7 @@ class TagSubscriber extends AbstractRuleSubscriber implements EventSubscriberInt
             }
         }
 
-        if ($request->isMethodSafe()) {
+        if ($this->isRequestSafe($request)) {
             $this->tagHandler->addTags($tags);
             if (HttpKernelInterface::MASTER_REQUEST === $event->getRequestType()) {
                 // For safe requests (GET and HEAD), set cache tags on response

--- a/Tests/Functional/EventListener/CacheControlSubscriberTest.php
+++ b/Tests/Functional/EventListener/CacheControlSubscriberTest.php
@@ -30,6 +30,6 @@ class CacheControlSubscriberTest extends WebTestCase
 
         $client->request('GET', '/noncached');
         $response = $client->getResponse();
-        $this->assertEquals('no-cache', $response->headers->get('Cache-Control'));
+        $this->assertContains('no-cache', $response->headers->get('Cache-Control'));
     }
 }

--- a/Tests/Functional/Fixtures/Controller/TagController.php
+++ b/Tests/Functional/Fixtures/Controller/TagController.php
@@ -19,6 +19,18 @@ use FOS\HttpCacheBundle\Configuration\Tag;
 class TagController extends Controller
 {
     /**
+     * Workaround to be compliant with all Symfony version.
+     *
+     * @param Request $request
+     *
+     * @return bool True if the request is safe
+     */
+    private function isRequestSafe(Request $request)
+    {
+        return method_exists($request, 'isMethodCacheable') ? $request->isMethodCacheable() : $request->isMethodSafe();
+    }
+
+    /**
      * @Tag("all-items")
      * @Tag("item-123")
      */
@@ -32,7 +44,7 @@ class TagController extends Controller
      */
     public function itemAction(Request $request, $id)
     {
-        if (!$request->isMethodSafe()) {
+        if (!$this->isRequestSafe($request)) {
             $this->container->get('fos_http_cache.handler.tag_handler')->invalidateTags(array('all-items'));
         }
 

--- a/Tests/Functional/Fixtures/Controller/TagController.php
+++ b/Tests/Functional/Fixtures/Controller/TagController.php
@@ -23,9 +23,9 @@ class TagController extends Controller
      *
      * @param Request $request
      *
-     * @return bool True if the request is safe
+     * @return bool True if the request is cacheable
      */
-    private function isRequestSafe(Request $request)
+    private function isRequestCacheable(Request $request)
     {
         return method_exists($request, 'isMethodCacheable') ? $request->isMethodCacheable() : $request->isMethodSafe();
     }
@@ -44,7 +44,7 @@ class TagController extends Controller
      */
     public function itemAction(Request $request, $id)
     {
-        if (!$this->isRequestSafe($request)) {
+        if (!$this->isRequestCacheable($request)) {
             $this->container->get('fos_http_cache.handler.tag_handler')->invalidateTags(array('all-items'));
         }
 

--- a/Tests/Unit/EventListener/CacheControlSubscriberTest.php
+++ b/Tests/Unit/EventListener/CacheControlSubscriberTest.php
@@ -224,7 +224,7 @@ class CacheControlSubscriberTest extends \PHPUnit_Framework_TestCase
         $subscriber->onKernelResponse($event);
         $newHeaders = $event->getResponse()->headers->all();
 
-        $this->assertEquals('no-cache', $newHeaders['cache-control'][0]);
+        $this->assertContains('no-cache', $newHeaders['cache-control'][0]);
     }
 
     public function testSkip()
@@ -242,7 +242,7 @@ class CacheControlSubscriberTest extends \PHPUnit_Framework_TestCase
         $subscriber->onKernelResponse($event);
         $newHeaders = $event->getResponse()->headers->all();
 
-        $this->assertEquals('no-cache', $newHeaders['cache-control'][0]);
+        $this->assertContains('no-cache', $newHeaders['cache-control'][0]);
     }
 
     public function testVary()
@@ -332,7 +332,7 @@ class CacheControlSubscriberTest extends \PHPUnit_Framework_TestCase
 
         $subscriber->onKernelResponse($event2);
         $newHeaders = $response2->headers->all();
-        $this->assertEquals('no-cache', $newHeaders['cache-control'][0]);
+        $this->assertContains('no-cache', $newHeaders['cache-control'][0]);
     }
 
     /**


### PR DESCRIPTION
Following https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/337 & https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/324

I've added Symfony 3.1 & 3.2 to Travis.
~~There seems to be a strange error on Symfony 3.1 with a _missing_ Twig template ..~~
It seems to appear only on my dev machine.