### PR TITLE
merge 1.3 to master

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -417,6 +417,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
                         ->scalarNode('custom_proxy_client')
                             ->info('Service name of a custom proxy client to use. With a custom client, generate_url_type defaults to ABSOLUTE_URL and tag support needs to be explicitly enabled. If no custom proxy client is specified, the first proxy client you configured is used.')
+                            ->cannotBeEmpty()
                         ->end()
                         ->enumNode('generate_url_type')
                             ->values([

--- a/src/EventListener/CacheControlListener.php
+++ b/src/EventListener/CacheControlListener.php
@@ -102,7 +102,7 @@ class CacheControlListener extends AbstractRuleListener implements EventSubscrib
         }
 
         // do not change cache directives on unsafe requests.
-        if ($this->skip || !$this->isRequestSafe($request)) {
+        if ($this->skip || !$request->isMethodCacheable()) {
             return;
         }
 
@@ -209,17 +209,5 @@ class CacheControlListener extends AbstractRuleListener implements EventSubscrib
                 $response->headers->addCacheControlDirective($option, $controls[$key]);
             }
         }
-    }
-
-    /**
-     * Decide whether to even look for matching rules with the current request.
-     *
-     * @param Request $request
-     *
-     * @return bool True if the request is safe and headers can be set
-     */
-    protected function isRequestSafe(Request $request)
-    {
-        return $request->isMethodCacheable();
     }
 }

--- a/tests/Unit/EventListener/CacheControlListenerTest.php
+++ b/tests/Unit/EventListener/CacheControlListenerTest.php
@@ -226,7 +226,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelResponse($event);
         $newHeaders = $event->getResponse()->headers->all();
 
-        $this->assertEquals('no-cache', $newHeaders['cache-control'][0]);
+        $this->assertContains('no-cache', $newHeaders['cache-control'][0]);
     }
 
     public function testSkip()
@@ -244,7 +244,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
         $listener->onKernelResponse($event);
         $newHeaders = $event->getResponse()->headers->all();
 
-        $this->assertEquals('no-cache', $newHeaders['cache-control'][0]);
+        $this->assertContains('no-cache', $newHeaders['cache-control'][0]);
     }
 
     public function testVary()
@@ -335,7 +335,7 @@ class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
 
         $listener->onKernelResponse($event2);
         $newHeaders = $response2->headers->all();
-        $this->assertEquals('no-cache', $newHeaders['cache-control'][0]);
+        $this->assertContains('no-cache', $newHeaders['cache-control'][0]);
     }
 
     /**


### PR DESCRIPTION
removing a lot that was added in 1.3 to support both older and newest versions of symfony correctly.

apart from getting some fixes in, this will make sure we can merge 1.3 to master again if there are further fixes to 1.3.