### PR TITLE
clarify documentation of cacheable response status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ Changelog
   to take a `ResponseMatcherInterface`.
   
 * Cacheable status codes are now configured globally 
-  (`cacheable.response.additional_status`).
+  (`cacheable.response.additional_status` or `cacheable.response.expression`).
 
 1.3.7
 -----

--- a/Resources/doc/includes/safe.rst
+++ b/Resources/doc/includes/safe.rst
@@ -1,4 +1,3 @@
 1. the HTTP request matches *all* criteria defined under ``match``
 2. the HTTP request is :term:`safe` (GET or HEAD)
-3. the HTTP response is considered :term:`cacheable` (override with
-   :ref:`additional_status`).
+3. the HTTP response is considered :term:`cacheable`

--- a/Resources/doc/reference/configuration/cacheable.rst
+++ b/Resources/doc/reference/configuration/cacheable.rst
@@ -7,6 +7,8 @@ cacheable
 Configure which responses are considered :term:`cacheable`. This bundle will
 only set Cache-Control headers, including tags etc., on cacheable responses.
 
+You can only set one of ``expression`` or ``additional_status``.
+
 .. _additional_status:
 
 ``additional_status``
@@ -34,7 +36,7 @@ You can add status codes to this list by setting ``additional_status``:
 **type**: ``string``
 
 An ExpressionLanguage expression to decide whether the response is considered
-cacheable. The expression can access the Response object with the response variable.
+cacheable. The expression can access the Response object with the response variable:
 
 .. code-block:: yaml
 
@@ -44,6 +46,8 @@ cacheable. The expression can access the Response object with the response varia
             response:
                 expression: "response.getStatusCode() >= 300"
 
-You cannot set both ``expression`` and ``additional_status``.
+When you configure an expression, *only* the expression is used to decide
+whether the response is cacheable. The default status codes from RFC 7231
+are ignored when specifying an expression.
 
 .. _RFC 7231: https://tools.ietf.org/html/rfc7231#section-6.1

--- a/Resources/doc/reference/glossary.rst
+++ b/Resources/doc/reference/glossary.rst
@@ -8,6 +8,9 @@ Glossary
         status code is one of 200, 203, 204, 206, 300, 301, 404, 405, 410, 414
         or 501.
 
+        In FOSHttpCacheBundle, this can be changed by configuring the
+        :doc:`cacheable.response section <configuration/cacheable>`.
+
     Safe
         A *request* is safe if its HTTP method is GET or HEAD. Safe methods
         only retrieve data and do not change the application state, and

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -141,7 +141,7 @@ class Configuration implements ConfigurationInterface
                                 ->end()
                                 ->scalarNode('expression')
                                     ->defaultNull()
-                                    ->info('Expression to decide whether response is cacheable.')
+                                    ->info('Expression to decide whether response is cacheable. Replaces the default status codes.')
                             ->end()
                         ->end()
 


### PR DESCRIPTION
follow up of #354

reading through the changes, i realized that expression leads to default status codes being ignored. i think that is fine, but wanted to make the documentation clear about that.