### PR TITLE
build for symfony 3.3 and only spellcheck in one build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ php:
   - 7.1
 
 env:
-  - SYMFONY_VERSION='3.1.*'
+  - SYMFONY_VERSION='3.3.*'
 
 branches:
   only:
@@ -37,6 +37,7 @@ matrix:
         - SYMFONY_VERSION='3.1.*'
         - PHPUNIT_FLAGS="--coverage-clover=coverage.clover"
         - COVERAGE=true
+        - DOCCHECK=true
     - php: 7.1
       env:
         - SYMFONY_VERSION='2.8.*'
@@ -60,8 +61,8 @@ before_script:
 
 script:
   - SYMFONY_DEPRECATIONS_HELPER=weak vendor/bin/phpunit ${PHPUNIT_FLAGS}
-  - make -C Resources/doc SPHINXOPTS='-nW' html
-  - make -C Resources/doc spelling
+  - if [[ "$DOCCHECK" = true ]]; then make -C Resources/doc SPHINXOPTS='-nW' html; fi
+  - if [[ "$DOCCHECK" = true ]]; then make -C Resources/doc spelling; fi
 
 after_script:
   - if [[ "$COVERAGE" = true ]]; then wget https://scrutinizer-ci.com/ocular.phar; fi

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -16,6 +16,7 @@ use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use FOS\HttpCacheBundle\Http\ResponseMatcher\ExpressionResponseMatcher;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\DefinitionDecorator;
@@ -227,10 +228,17 @@ class FOSHttpCacheExtension extends Extension
         $id = $this->getAlias().'.request_matcher.'.md5($serialized).sha1($serialized);
 
         if (!$container->hasDefinition($id)) {
-            $container
-                ->setDefinition($id, new DefinitionDecorator($this->getAlias().'.request_matcher'))
-                ->setArguments($arguments)
-            ;
+            if (class_exists(ChildDefinition::class)) {
+                $container
+                    ->setDefinition($id, new ChildDefinition($this->getAlias().'.request_matcher'))
+                    ->setArguments($arguments)
+                ;
+            } else {
+                $container
+                    ->setDefinition($id, new DefinitionDecorator($this->getAlias().'.request_matcher'))
+                    ->setArguments($arguments)
+                ;
+            }
         }
 
         return new Reference($id);

--- a/tests/Unit/DependencyInjection/Compiler/HashGeneratorPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/HashGeneratorPassTest.php
@@ -44,7 +44,12 @@ class HashGeneratorPassTest extends \PHPUnit_Framework_TestCase
         $config = $this->getBaseConfig();
         $this->extension->load([$config], $container);
         $this->userContextListenerPass->process($container);
-        $this->assertCount(21, $container->getDefinitions());
+        if ($container->hasDefinition('service_container')) {
+            // symfony 3.3+
+            $this->assertCount(22, $container->getDefinitions());
+        } else {
+            $this->assertCount(21, $container->getDefinitions());
+        }
     }
 
     /**


### PR DESCRIPTION
realized that we don't test with symfony 3.3. and hhvm build works but sphinx does not - actually building the doc once is enough.