### PR TITLE
cache control listener should only set caching headers on cacheable responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+2.0.1
+-----
+
+### Fixes
+
+* When setting cache headers on the response, the `cacheable` configuration is
+  now respected.
+  **BC BREAK**: The signature of the CacheControlListener has changed. It now
+  needs a RuleMatcherInterface as first argument.
+
 2.0.0
 -----
 

--- a/src/Resources/config/cache_control_listener.xml
+++ b/src/Resources/config/cache_control_listener.xml
@@ -7,6 +7,7 @@
     <services>
         <service id="fos_http_cache.event_listener.cache_control"
                  class="FOS\HttpCacheBundle\EventListener\CacheControlListener">
+            <argument type="service" id="fos_http_cache.rule_matcher.cacheable"/>
             <argument>%fos_http_cache.debug_header%</argument>
             <tag name="kernel.event_subscriber" />
         </service>


### PR DESCRIPTION
the documentation on http://foshttpcachebundle.readthedocs.io/en/latest/reference/configuration/cacheable.html claims that cache-control headers are only set on cacheable responses. but we missed to inject the cacheable matcher to the cache control listener.

this is a BC break for the listener class, but i think the bug is severe enough that we want to fix it nonetheless. the listener is more of an internal class to implement the bundle behaviour. should we mark the listeners as `@internal` and say you are not supposed to code-reuse them?

Options
* [ ] If we finalize this approach, adjust the unit test CacheControlListenerTest to pass a rule matcher to the CacheControlListener and write another functional test.
* [ ] Or we could change addRule of the CacheControlListener back to RuleMatcher instead of RequestMatcher and re-introduce match_response configuration. However, this leads to weird interactions with the global cacheable configuration. 

I opt for a note in the documentation to say that if you want headers to be always set regardless of response status, you should write your own event listener.

FTR: we removed the response matching in https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/354 but from how i read this we mostly were thinking about invalidation and tagging and less about the header rules.