### PR TITLE
Fix deprecated console.exception event

### DIFF
--- a/src/EventListener/InvalidationListener.php
+++ b/src/EventListener/InvalidationListener.php
@@ -145,7 +145,6 @@ class InvalidationListener extends AbstractRuleListener implements EventSubscrib
             KernelEvents::TERMINATE => 'onKernelTerminate',
             KernelEvents::EXCEPTION => 'onKernelException',
             ConsoleEvents::TERMINATE => 'onConsoleTerminate',
-            ConsoleEvents::EXCEPTION => 'onConsoleTerminate',
         ];
     }
 


### PR DESCRIPTION
This event is deprecated since symfony 3.3. And listening to it seems useless here anyway because the terminate event is already used which is triggered after the exception event in any case. So they are not exclusive.