### PR TITLE
Support FQCN service names for Sensio Framework Extra Bundle

### DIFF
--- a/DependencyInjection/Compiler/TagSubscriberPass.php
+++ b/DependencyInjection/Compiler/TagSubscriberPass.php
@@ -25,12 +25,18 @@ class TagSubscriberPass implements CompilerPassInterface
     public function process(ContainerBuilder $container)
     {
         if (true === $container->getParameter('fos_http_cache.compiler_pass.tag_annotations')
-            && !$container->has('sensio_framework_extra.controller.listener')
+            && !$this->hasControllerListener($container)
         ) {
             throw new \RuntimeException(
                 'Tag support requires SensioFrameworkExtraBundle’s ControllerListener for the annotations. '
                 .'Please install sensio/framework-extra-bundle and add it to your AppKernel.'
             );
         }
+    }
+
+    private function hasControllerListener(ContainerBuilder $container)
+    {
+        return $container->has('sensio_framework_extra.controller.listener') ||
+            $container->has('Sensio\\Bundle\\FrameworkExtraBundle\\EventListener\\ControllerListener');
     }
 }


### PR DESCRIPTION
From version 4.0 and up, `ControllerListener` service from `SensioFrameworkExtraBundle` has been renamed to use FQCN as service name, so this adds support for the old and new name.

`master` branch also needs this fix, however, the compiler pass has been renamed to `TagListenerPass`, so probably needs manual merge.