### PR TITLE
make sure no caching happens when hash mismatch

### DIFF
--- a/EventListener/UserContextSubscriber.php
+++ b/EventListener/UserContextSubscriber.php
@@ -166,8 +166,13 @@ class UserContextSubscriber implements EventSubscriberInterface
         if ($request->headers->has($this->hashHeader)) {
             // hash has changed, session has most certainly changed, prevent setting incorrect cache
             if (!is_null($this->hash) && $this->hash !== $request->headers->get($this->hashHeader)) {
-                $response->setClientTtl(0);
+                $response->setCache([
+                    'max_age' => 0,
+                    's_maxage' => 0,
+                    'private' => true,
+                ]);
                 $response->headers->addCacheControlDirective('no-cache');
+                $response->headers->addCacheControlDirective('no-store');
 
                 return;
             }

--- a/Tests/Unit/EventListener/UserContextSubscriberTest.php
+++ b/Tests/Unit/EventListener/UserContextSubscriberTest.php
@@ -259,7 +259,7 @@ class UserContextSubscriberTest extends \PHPUnit_Framework_TestCase
         $userContextSubscriber->onKernelResponse($event);
 
         $this->assertFalse($event->getResponse()->headers->has('Vary'));
-        $this->assertEquals('max-age=0, no-cache, private', $event->getResponse()->headers->get('Cache-Control'));
+        $this->assertEquals('max-age=0, no-cache, no-store, private, s-maxage=0', $event->getResponse()->headers->get('Cache-Control'));
     }
 
     protected function getKernelRequestEvent(Request $request, $type = HttpKernelInterface::MASTER_REQUEST)


### PR DESCRIPTION
without the setSharedMaxAge the cache control listener will still add an s-maxage which is at least confusing and depending on caching proxy implementation could void the no-cache.

also, symfony httpcache looks only for no-store and private, but not for no-cache when deciding if it may cache.

fix #399