### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/tests/Unit/CacheManagerTest.php
+++ b/tests/Unit/CacheManagerTest.php
@@ -15,9 +15,10 @@ use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCacheBundle\CacheManager;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class CacheManagerTest extends \PHPUnit_Framework_TestCase
+class CacheManagerTest extends TestCase
 {
     protected $proxyClient;
 

--- a/tests/Unit/Command/BaseInvalidateCommandTest.php
+++ b/tests/Unit/Command/BaseInvalidateCommandTest.php
@@ -13,11 +13,12 @@ namespace FOS\HttpCacheBundle\Tests\Unit\Command;
 
 use FOS\HttpCacheBundle\CacheManager;
 use FOS\HttpCacheBundle\Command\InvalidatePathCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class BaseInvalidateCommandTest extends \PHPUnit_Framework_TestCase
+class BaseInvalidateCommandTest extends TestCase
 {
     public function testContainerAccess()
     {

--- a/tests/Unit/Command/InvalidatePathCommandTest.php
+++ b/tests/Unit/Command/InvalidatePathCommandTest.php
@@ -13,10 +13,11 @@ namespace FOS\HttpCacheBundle\Tests\Unit\Command;
 
 use FOS\HttpCacheBundle\CacheManager;
 use FOS\HttpCacheBundle\Command\InvalidatePathCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class InvalidatePathCommandTest extends \PHPUnit_Framework_TestCase
+class InvalidatePathCommandTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/Unit/Command/InvalidateRegexCommandTest.php
+++ b/tests/Unit/Command/InvalidateRegexCommandTest.php
@@ -13,10 +13,11 @@ namespace FOS\HttpCacheBundle\Tests\Unit\Command;
 
 use FOS\HttpCacheBundle\CacheManager;
 use FOS\HttpCacheBundle\Command\InvalidateRegexCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class InvalidateRegexCommandTest extends \PHPUnit_Framework_TestCase
+class InvalidateRegexCommandTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/Unit/Command/InvalidateTagCommandTest.php
+++ b/tests/Unit/Command/InvalidateTagCommandTest.php
@@ -13,10 +13,11 @@ namespace FOS\HttpCacheBundle\Tests\Unit\Command;
 
 use FOS\HttpCacheBundle\CacheManager;
 use FOS\HttpCacheBundle\Command\InvalidateTagCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class InvalidateTagCommandTest extends \PHPUnit_Framework_TestCase
+class InvalidateTagCommandTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/Unit/Command/PathSanityCheckTest.php
+++ b/tests/Unit/Command/PathSanityCheckTest.php
@@ -12,8 +12,9 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\Command;
 
 use FOS\HttpCacheBundle\Command\PathSanityCheck;
+use PHPUnit\Framework\TestCase;
 
-class PathSanityCheckTest extends \PHPUnit_Framework_TestCase
+class PathSanityCheckTest extends TestCase
 {
     public function pathProvider()
     {

--- a/tests/Unit/Command/RefreshPathCommandTest.php
+++ b/tests/Unit/Command/RefreshPathCommandTest.php
@@ -13,10 +13,11 @@ namespace FOS\HttpCacheBundle\Tests\Unit\Command;
 
 use FOS\HttpCacheBundle\CacheManager;
 use FOS\HttpCacheBundle\Command\RefreshPathCommand;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class RefreshPathCommandTest extends \PHPUnit_Framework_TestCase
+class RefreshPathCommandTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/Unit/Configuration/InvalidateRouteTest.php
+++ b/tests/Unit/Configuration/InvalidateRouteTest.php
@@ -12,11 +12,12 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\Configuration;
 
 use FOS\HttpCacheBundle\Configuration\InvalidateRoute;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test the @InvalidateRoute annotation.
  */
-class InvalidateRouteTest extends \PHPUnit_Framework_TestCase
+class InvalidateRouteTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/Unit/Configuration/TagTest.php
+++ b/tests/Unit/Configuration/TagTest.php
@@ -12,11 +12,12 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\Configuration;
 
 use FOS\HttpCacheBundle\Configuration\Tag;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test the @InvalidateRoute annotation.
  */
-class TagTest extends \PHPUnit_Framework_TestCase
+class TagTest extends TestCase
 {
     /**
      * @expectedException \FOS\HttpCacheBundle\Exception\InvalidTagException

--- a/tests/Unit/DependencyInjection/Compiler/HashGeneratorPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/HashGeneratorPassTest.php
@@ -13,11 +13,12 @@ namespace FOS\HttpCacheBundle\Tests\Unit\DependencyInjection\Compiler;
 
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
-class HashGeneratorPassTest extends \PHPUnit_Framework_TestCase
+class HashGeneratorPassTest extends TestCase
 {
     /**
      * @var FOSHttpCacheExtension

--- a/tests/Unit/DependencyInjection/Compiler/LoggerPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/LoggerPassTest.php
@@ -13,11 +13,12 @@ namespace FOS\HttpCacheBundle\Tests\Unit\DependencyInjection\Compiler;
 
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\LoggerPass;
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
-class LoggerPassTest extends \PHPUnit_Framework_TestCase
+class LoggerPassTest extends TestCase
 {
     public function testLogger()
     {

--- a/tests/Unit/DependencyInjection/Compiler/TagListenerPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/TagListenerPassTest.php
@@ -13,10 +13,11 @@ namespace FOS\HttpCacheBundle\Tests\Unit\DependencyInjection\Compiler;
 
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\TagListenerPass;
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 
-class TagListenerPassTest extends \PHPUnit_Framework_TestCase
+class TagListenerPassTest extends TestCase
 {
     /**
      * @expectedException \RuntimeException

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\DependencyInjection;
 
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
@@ -21,7 +22,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\Routing\Router;
 
-class FOSHttpCacheExtensionTest extends \PHPUnit_Framework_TestCase
+class FOSHttpCacheExtensionTest extends TestCase
 {
     /**
      * @var FOSHttpCacheExtension

--- a/tests/Unit/EventListener/CacheControlListenerTest.php
+++ b/tests/Unit/EventListener/CacheControlListenerTest.php
@@ -13,12 +13,13 @@ namespace FOS\HttpCacheBundle\Tests\Unit\EventListener;
 
 use FOS\HttpCacheBundle\EventListener\CacheControlListener;
 use FOS\HttpCacheBundle\Http\RuleMatcherInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class CacheControlListenerTest extends \PHPUnit_Framework_TestCase
+class CacheControlListenerTest extends TestCase
 {
     public function testDefaultHeaders()
     {

--- a/tests/Unit/EventListener/InvalidationListenerTest.php
+++ b/tests/Unit/EventListener/InvalidationListenerTest.php
@@ -17,6 +17,7 @@ use FOS\HttpCacheBundle\Configuration\InvalidateRoute;
 use FOS\HttpCacheBundle\EventListener\InvalidationListener;
 use FOS\HttpCacheBundle\Http\RuleMatcherInterface;
 use Mockery\MockInterface;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Console\Event\ConsoleEvent;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\HttpFoundation\Request;
@@ -28,7 +29,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Route;
 use Symfony\Component\Routing\RouteCollection;
 
-class InvalidationListenerTest extends \PHPUnit_Framework_TestCase
+class InvalidationListenerTest extends TestCase
 {
     /**
      * @var CacheManager|MockInterface

--- a/tests/Unit/EventListener/TagListenerTest.php
+++ b/tests/Unit/EventListener/TagListenerTest.php
@@ -16,13 +16,14 @@ use FOS\HttpCacheBundle\Configuration\Tag;
 use FOS\HttpCacheBundle\EventListener\TagListener;
 use FOS\HttpCacheBundle\Http\RuleMatcherInterface;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class TagListenerTest extends \PHPUnit_Framework_TestCase
+class TagListenerTest extends TestCase
 {
     /**
      * @var CacheManager|\Mockery\Mock

--- a/tests/Unit/EventListener/UserContextListenerTest.php
+++ b/tests/Unit/EventListener/UserContextListenerTest.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\Tests\Unit\EventListener;
 
 use FOS\HttpCache\UserContext\HashGenerator;
 use FOS\HttpCacheBundle\EventListener\UserContextListener;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
@@ -20,7 +21,7 @@ use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 
-class UserContextListenerTest extends \PHPUnit_Framework_TestCase
+class UserContextListenerTest extends TestCase
 {
     /**
      * @expectedException \InvalidArgumentException

--- a/tests/Unit/Http/RequestMatcher/QuerystringRequestMatcherTest.php
+++ b/tests/Unit/Http/RequestMatcher/QuerystringRequestMatcherTest.php
@@ -12,9 +12,10 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\Http\RequestMatcher;
 
 use FOS\HttpCacheBundle\Http\RequestMatcher\QuerystringRequestMatcher;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
-class QuerystringRequestMatcherTest extends \PHPUnit_Framework_TestCase
+class QuerystringRequestMatcherTest extends TestCase
 {
     public function testMatchesReturnsFalseIfParentCallFails()
     {

--- a/tests/Unit/Http/RuleMatcherTest.php
+++ b/tests/Unit/Http/RuleMatcherTest.php
@@ -13,11 +13,12 @@ namespace FOS\HttpCacheBundle\Tests\Unit\Http;
 
 use FOS\HttpCacheBundle\Http\ResponseMatcher\CacheableResponseMatcher;
 use FOS\HttpCacheBundle\Http\RuleMatcher;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
 use Symfony\Component\HttpFoundation\Response;
 
-class RuleMatcherTest extends \PHPUnit_Framework_TestCase
+class RuleMatcherTest extends TestCase
 {
     public function testRequestMatcherCalled()
     {

--- a/tests/Unit/Http/SymfonyResponseTaggerTest.php
+++ b/tests/Unit/Http/SymfonyResponseTaggerTest.php
@@ -13,9 +13,10 @@ namespace FOS\HttpCacheBundle\Tests\Unit;
 
 use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
-class SymfonyResponseTaggerTest extends \PHPUnit_Framework_TestCase
+class SymfonyResponseTaggerTest extends TestCase
 {
     private $proxyClient;
 

--- a/tests/Unit/UserContext/AnonymousRequestMatcherTest.php
+++ b/tests/Unit/UserContext/AnonymousRequestMatcherTest.php
@@ -12,10 +12,10 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\UserContext;
 
 use FOS\HttpCacheBundle\UserContext\AnonymousRequestMatcher;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
-class AnonymousRequestMatcherTest extends PHPUnit_Framework_TestCase
+class AnonymousRequestMatcherTest extends TestCase
 {
     public function testMatchAnonymousRequest()
     {

--- a/tests/Unit/UserContext/RequestMatcherTest.php
+++ b/tests/Unit/UserContext/RequestMatcherTest.php
@@ -12,9 +12,10 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\UserContext;
 
 use FOS\HttpCacheBundle\UserContext\RequestMatcher;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
-class RequestMatcherTest extends \PHPUnit_Framework_TestCase
+class RequestMatcherTest extends TestCase
 {
     public function testMatch()
     {

--- a/tests/Unit/UserContext/RoleProviderTest.php
+++ b/tests/Unit/UserContext/RoleProviderTest.php
@@ -13,11 +13,12 @@ namespace FOS\HttpCacheBundle\Tests\Unit\UserContext;
 
 use FOS\HttpCache\UserContext\UserContext;
 use FOS\HttpCacheBundle\UserContext\RoleProvider;
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Core\Role\Role;
 
-class RoleProviderTest extends \PHPUnit_Framework_TestCase
+class RoleProviderTest extends TestCase
 {
     public function testProvider()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).