### PR TITLE
Symfony 4 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,11 +73,7 @@ before_script:
   - composer update $COMPOSER_FLAGS
 
 script:
-  - if [ "$SYMFONY_DEPRECATIONS_HELPER_VALUE" != "" ]
-    then
-      SYMFONY_DEPRECATIONS_HELPER=$SYMFONY_DEPRECATIONS_HELPER_VALUE vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}
-    else
-      SYMFONY_DEPRECATIONS_HELPER=weak vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}
+  - if [[ "$SYMFONY_DEPRECATIONS_HELPER_VALUE" != "" ]]; then SYMFONY_DEPRECATIONS_HELPER=$SYMFONY_DEPRECATIONS_HELPER_VALUE vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}; else SYMFONY_DEPRECATIONS_HELPER=weak vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}; fi;
   - if [[ "$DOCCHECK" = true ]]; then make -C Resources/doc SPHINXOPTS='-nW' html; fi
   - if [[ "$DOCCHECK" = true ]]; then make -C Resources/doc spelling; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,10 +51,6 @@ matrix:
       env:
         - SYMFONY_VERSION='3.2.*'
         - SYMFONY_PHPUNIT_VERSION=5.5
-    - php: 7.1
-      env:
-        - DEPENDENCIES=beta
-        - SYMFONY_PHPUNIT_VERSION=5.5
     - php: hhvm
       dist: trusty
 
@@ -62,7 +58,6 @@ install:
   - if [[ "$DOCCHECK" = true ]]; then pip install -qr Resources/doc/requirements.txt --user; fi
 
 before_install:
-  - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ matrix:
       env:
         - SYMFONY_VERSION='3.4.*'
         - SYMFONY_PHPUNIT_VERSION=5.5
-        - $SYMFONY_DEPRECATIONS_HELPER_VALUE=52
+        - SYMFONY_DEPRECATIONS_HELPER_VALUE=52
     - php: 7.2
       env:
         - SYMFONY_VERSION='4.0.*'

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ php:
 
 env:
   - SYMFONY_VERSION='3.3.*'
-  - SYMFONY_DEPRECATIONS_HELPER_VALUE=weak
 
 branches:
   only:
@@ -74,7 +73,11 @@ before_script:
   - composer update $COMPOSER_FLAGS
 
 script:
-  - SYMFONY_DEPRECATIONS_HELPER=$SYMFONY_DEPRECATIONS_HELPER_VALUE vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}
+  - if [ "$SYMFONY_DEPRECATIONS_HELPER_VALUE" != "" ]
+    then
+      SYMFONY_DEPRECATIONS_HELPER=$SYMFONY_DEPRECATIONS_HELPER_VALUE vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}
+    else
+      SYMFONY_DEPRECATIONS_HELPER=weak vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}
   - if [[ "$DOCCHECK" = true ]]; then make -C Resources/doc SPHINXOPTS='-nW' html; fi
   - if [[ "$DOCCHECK" = true ]]; then make -C Resources/doc spelling; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,14 @@ matrix:
       env:
         - SYMFONY_VERSION='3.2.*'
         - SYMFONY_PHPUNIT_VERSION=5.5
+    - php: 7.2
+      env:
+        - SYMFONY_VERSION='3.4.*'
+        - SYMFONY_PHPUNIT_VERSION=5.5
+    - php: 7.2
+      env:
+        - SYMFONY_VERSION='4.0.*'
+        - SYMFONY_PHPUNIT_VERSION=5.5
     - php: hhvm
       dist: trusty
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ php:
 
 env:
   - SYMFONY_VERSION='3.3.*'
+  - SYMFONY_DEPRECATIONS_HELPER_VALUE=weak
 
 branches:
   only:
@@ -55,6 +56,7 @@ matrix:
       env:
         - SYMFONY_VERSION='3.4.*'
         - SYMFONY_PHPUNIT_VERSION=5.5
+        - $SYMFONY_DEPRECATIONS_HELPER_VALUE=52
     - php: 7.2
       env:
         - SYMFONY_VERSION='4.0.*'
@@ -72,7 +74,7 @@ before_script:
   - composer update $COMPOSER_FLAGS
 
 script:
-  - SYMFONY_DEPRECATIONS_HELPER=weak vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}
+  - SYMFONY_DEPRECATIONS_HELPER=$SYMFONY_DEPRECATIONS_HELPER_VALUE vendor/bin/simple-phpunit ${PHPUNIT_FLAGS}
   - if [[ "$DOCCHECK" = true ]]; then make -C Resources/doc SPHINXOPTS='-nW' html; fi
   - if [[ "$DOCCHECK" = true ]]; then make -C Resources/doc spelling; fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,10 @@ matrix:
       env:
         - SYMFONY_VERSION='3.2.*'
         - SYMFONY_PHPUNIT_VERSION=5.5
+    - php: 7.1
+      env:
+        - DEPENDENCIES=beta
+        - SYMFONY_PHPUNIT_VERSION=5.5
     - php: hhvm
       dist: trusty
 
@@ -58,6 +62,7 @@ install:
   - if [[ "$DOCCHECK" = true ]]; then pip install -qr Resources/doc/requirements.txt --user; fi
 
 before_install:
+  - if [ "$DEPENDENCIES" = "beta" ]; then composer config minimum-stability beta; fi;
   - sh -c 'if [ "$SYMFONY_VERSION" != "" ]; then composer require --dev --no-update symfony/symfony=$SYMFONY_VERSION; fi;'
 
 before_script:

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^5.6.0||^7.0.0",
-        "friendsofsymfony/http-cache": "^2.1.x-dev",
+        "friendsofsymfony/http-cache": "^2.1@dev",
         "symfony/framework-bundle": "^2.8||^3.0||^4.0",
         "symfony/http-foundation": "~2.8.13||^3.1.6||^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "monolog/monolog": "*",
         "sensio/framework-extra-bundle": "^3.0",
         "symfony/symfony": "^2.8||^3.0||^4.0",
-        "symfony/phpunit-bridge": "^3.2||^4.0",
+        "symfony/phpunit-bridge": "^3.2",
         "symfony/expression-language": "^2.4||^3.0||^4.0",
         "symfony/monolog-bundle": "^2.3||^3.0||^4.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^5.6.0||^7.0.0",
-        "friendsofsymfony/http-cache": "^2.0.0",
+        "friendsofsymfony/http-cache": "^2.1.x-dev",
         "symfony/framework-bundle": "^2.8||^3.0||^4.0",
         "symfony/http-foundation": "~2.8.13||^3.1.6||^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -23,8 +23,8 @@
     "require": {
         "php": "^5.6.0||^7.0.0",
         "friendsofsymfony/http-cache": "^2.0.0",
-        "symfony/framework-bundle": "^2.8||^3.0",
-        "symfony/http-foundation": "~2.8.13||^3.1.6"
+        "symfony/framework-bundle": "^2.8||^3.0||^4.0",
+        "symfony/http-foundation": "~2.8.13||^3.1.6||^4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.5.0",
@@ -33,10 +33,10 @@
         "mockery/mockery": "0.9.*",
         "monolog/monolog": "*",
         "sensio/framework-extra-bundle": "^3.0",
-        "symfony/symfony": "^2.8||^3.0",
-        "symfony/phpunit-bridge": "^3.2",
-        "symfony/expression-language": "^2.4||^3.0",
-        "symfony/monolog-bundle": "^2.3||^3.0",
+        "symfony/symfony": "^2.8||^3.0||^4.0",
+        "symfony/phpunit-bridge": "^3.2||^4.0",
+        "symfony/expression-language": "^2.4||^3.0||^4.0",
+        "symfony/monolog-bundle": "^2.3||^3.0||^4.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",
         "matthiasnoback/symfony-dependency-injection-test": "^0.7.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "monolog/monolog": "*",
         "sensio/framework-extra-bundle": "^3.0",
         "symfony/symfony": "^2.8||^3.0||^4.0",
-        "symfony/phpunit-bridge": "^3.2",
+        "symfony/phpunit-bridge": "^3.2||^4.0",
         "symfony/expression-language": "^2.4||^3.0||^4.0",
         "symfony/monolog-bundle": "^2.3||^3.0||^4.0",
         "polishsymfonycommunity/symfony-mocker-container": "^1.0",


### PR DESCRIPTION
Symfony 4 compatibility based on [this](https://symfony.com/blog/help…ing-prepare-for-symfony-4-bundle-support) article.

#SymfonyConHackday2017

* [ ] make test app kernel loadable with psr-3, add KERNEL_CLASS to phpunit (but keep KERNEL_DIR for testing older versions of symfony)
* [ ] make cache_manager public
* [ ] find solution for fos_http_cache.event_listener.tag, symfony_response_tagger, proxy_client.varnish,  - either get access without having to get it from the container, or make it public for the test env only
* [ ] `ServiceTest::testCanBeLoaded` => guess we should use the container builder instead of the compiled container in that test. most of those services need not be public probably. 
