### PR TITLE
adjust to session listener changes in symfony 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.2.1 (unreleased)
+------------------
+
+Adjust session listener decorator to handle Symfony 4.1 breaking behaviour change.
+
 2.2.0
 -----
 


### PR DESCRIPTION
The SessionListener in Symfony 4.1 is changed and does the `$session->save()` itself.

Fix #437