### PR TITLE
adjust session listener to symfony 4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.2.1 (unreleased)
+------------------
+
+### Fixed
+
+* Adjust user context listener to handle Symfony 4.1 breaking behaviour change.
+
 2.2.0
 -----
 

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -326,8 +326,12 @@ class FOSHttpCacheExtension extends Extension
                 ->setAbstract(false);
         }
 
-        // Only decorate default session listener for Symfony 3.4+
-        if (version_compare(Kernel::VERSION, '3.4', '>=')) {
+        // Only decorate default SessionListener for Symfony 3.4 - 4.0
+        // For Symfony 4.1+, the UserContextListener sets the header that tells
+        // the SessionListener to leave the cache-control header unchanged.
+        if (version_compare(Kernel::VERSION, '3.4', '>=')
+            && version_compare(Kernel::VERSION, '4.1', '<')
+        ) {
             $container->getDefinition('fos_http_cache.user_context.session_listener')
                 ->setArgument(1, strtolower($config['user_hash_header']))
                 ->setArgument(2, $completeUserIdentifierHeaders);

--- a/src/EventListener/SessionListener.php
+++ b/src/EventListener/SessionListener.php
@@ -19,11 +19,14 @@ use Symfony\Component\HttpKernel\EventListener\SessionListener as BaseSessionLis
 /**
  * Decorates the default Symfony session listener.
  *
- * The default Symfony session listener automatically makes responses private
- * in case the session was started. This kills the user context feature of
- * FOSHttpCache. We disable the default behaviour only if the user context header
- * is part of the Vary headers to reduce the possible impacts on other parts
- * of your application.
+ * Since Symfony 3.4, the default Symfony session listener automatically
+ * overwrites the Cache-Control headers to `private` in case the session has
+ * been started. This destroys the user context feature of FOSHttpCache.
+ * Since Symfony 4.1, there is a header we can set to skip this behaviour. We
+ * set that header in UserContextListener.
+ * For Symfony 3.4 and 4.0, we decorate the listener to only call the default
+ * behaviour if `Vary` contains neither the context hash header nor any of the
+ * user identifier headers, to avoid impacts on other parts of your application.
  *
  * @author Yanick Witschi <yanick.witschi@terminal42.ch>
  */

--- a/src/EventListener/UserContextListener.php
+++ b/src/EventListener/UserContextListener.php
@@ -137,7 +137,7 @@ class UserContextListener implements EventSubscriberInterface
             $response->setClientTtl($this->options['ttl']);
             $response->setVary($this->options['user_identifier_headers']);
             $response->setPublic();
-            if (version_compare(Kernel::VERSION, '4.1', '>=')) {
+            if (4 <= Kernel::MAJOR_VERSION && 1 <= Kernel::MINOR_VERSION) {
                 // header to avoid Symfony SessionListener overwriting the response to private
                 $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 1);
             }
@@ -181,8 +181,8 @@ class UserContextListener implements EventSubscriberInterface
         $vary = $response->getVary();
 
         if ($request->headers->has($this->options['user_hash_header'])) {
-            // hash has changed, session has most certainly changed, prevent setting incorrect cache
             if (null !== $this->hash && $this->hash !== $request->headers->get($this->options['user_hash_header'])) {
+                // hash has changed, session has most certainly changed, prevent setting incorrect cache
                 $response->setCache([
                     'max_age' => 0,
                     's_maxage' => 0,
@@ -198,7 +198,7 @@ class UserContextListener implements EventSubscriberInterface
                 && !in_array($this->options['user_hash_header'], $vary)
             ) {
                 $vary[] = $this->options['user_hash_header'];
-                if (version_compare(Kernel::VERSION, '4.1', '>=')) {
+                if (4 <= Kernel::MAJOR_VERSION && 1 <= Kernel::MINOR_VERSION) {
                     // header to avoid Symfony SessionListener overwriting the response to private
                     $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 1);
                 }

--- a/tests/Functional/EventListener/UserContextListenerTest.php
+++ b/tests/Functional/EventListener/UserContextListenerTest.php
@@ -17,14 +17,33 @@ class UserContextListenerTest extends WebTestCase
 {
     public function testHashLookup()
     {
-        $client = static::createClient();
+        $client = static::createClient([], [
+            'PHP_AUTH_USER' => 'user',
+            'PHP_AUTH_PW' => 'user',
+        ]);
 
-        $client->request('GET', '/_fos_user_context_hash', [], [], [
+        $client->request('GET', '/secured_area/_fos_user_context_hash', [], [], [
             'HTTP_ACCEPT' => 'application/vnd.fos.user-context-hash',
         ]);
         $response = $client->getResponse();
 
         $this->assertTrue($response->headers->has('X-User-Context-Hash'), 'X-User-Context-Hash header missing on the response');
+        $this->assertEquals('5224d8f5b85429624e2160e538a3376a479ec87b89251b295c44ecbf7498ea3c', $response->headers->get('X-User-Context-Hash'), 'Not the expected context hash');
+        $this->assertEquals('max-age=60, public', $response->headers->get('Cache-Control'));
+    }
+
+    public function testSessionCanBeCached()
+    {
+        $client = static::createClient([], [
+            'PHP_AUTH_USER' => 'user',
+            'PHP_AUTH_PW' => 'user',
+        ]);
+        $client->request('GET', '/secured_area/cached_session', [], [], [
+            'HTTP_X-User-Context-Hash' => '5224d8f5b85429624e2160e538a3376a479ec87b89251b295c44ecbf7498ea3c',
+        ]);
+        $response = $client->getResponse();
+
+        $this->assertTrue($response->isSuccessful());
         $this->assertEquals('max-age=60, public', $response->headers->get('Cache-Control'));
     }
 }

--- a/tests/Functional/Fixtures/Controller/TestController.php
+++ b/tests/Functional/Fixtures/Controller/TestController.php
@@ -20,4 +20,14 @@ class TestController extends Controller
     {
         return new Response('content '.$id);
     }
+
+    public function sessionAction()
+    {
+        $this->container->get('session')->start();
+
+        $response = new Response('session');
+        $response->setCache(['max_age' => 60, 'public' => true]);
+
+        return $response;
+    }
 }

--- a/tests/Functional/Fixtures/app/config/config.yml
+++ b/tests/Functional/Fixtures/app/config/config.yml
@@ -34,7 +34,7 @@ fos_http_cache:
     rules:
       -
         match:
-          path: ^/cached
+          path: ^/cached/
         tags: [area]
         tag_expressions: ["'area-'~id"]
   user_context:

--- a/tests/Functional/Fixtures/app/config/routing.yml
+++ b/tests/Functional/Fixtures/app/config/routing.yml
@@ -37,6 +37,10 @@ test_cached:
   defaults: { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\TestController::contentAction }
   methods:  [GET,PUT]
 
+test_cached_session:
+  path:  /secured_area/cached_session
+  defaults: { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\TestController::sessionAction }
+
 test_noncached:
   path:  /noncached
   defaults: { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\TestController::contentAction }
@@ -49,4 +53,4 @@ test_flash:
   defaults: { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\FlashMessageController::flashAction }
 
 user_context_hash:
-    path: /_fos_user_context_hash
+    path: /secured_area/_fos_user_context_hash

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -497,16 +497,20 @@ class FOSHttpCacheExtensionTest extends TestCase
         $container = $this->createContainer();
         $this->extension->load($config, $container);
 
-        // The whole definition should be removed for Symfony < 3.4
-        if (version_compare(Kernel::VERSION, '3.4', '<')) {
-            $this->assertFalse($container->hasDefinition('fos_http_cache.user_context.session_listener'));
-        } else {
+        // The decorator is only needed for Symfony 3.4 and 4.0
+        // Before 3.4 the cache header is not overwritten.
+        // From 4.1 on, we use the AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER
+        if (version_compare(Kernel::VERSION, '3.4', '>=')
+            && version_compare(Kernel::VERSION, '4.1', '<')
+        ) {
             $this->assertTrue($container->hasDefinition('fos_http_cache.user_context.session_listener'));
 
             $definition = $container->getDefinition('fos_http_cache.user_context.session_listener');
 
             $this->assertSame('x-bar', $definition->getArgument(1));
             $this->assertSame(['x-foo'], $definition->getArgument(2));
+        } else {
+            $this->assertFalse($container->hasDefinition('fos_http_cache.user_context.session_listener'));
         }
     }
 


### PR DESCRIPTION
Use https://github.com/symfony/symfony/pull/26681 to make the session listener work with Symfony 4.1

Fix #437
Replaces #438