### PR TITLE
[BLOCKED] upgrade for symfony 4.1

### DIFF
--- a/tests/Functional/Fixtures/app/config/config_40.yml
+++ b/tests/Functional/Fixtures/app/config/config_40.yml
@@ -5,3 +5,4 @@ imports:
 
 twig:
   default_path: "%kernel.root_dir%/Resources/views"
+  strict_variables: "%kernel.debug%"

--- a/tests/Functional/Fixtures/app/config/routing.yml
+++ b/tests/Functional/Fixtures/app/config/routing.yml
@@ -1,24 +1,24 @@
 tag_list:
   path:  /tag/list
-  defaults: { _controller: tag_controller:listAction }
+  defaults: { _controller: tag_controller::listAction }
   methods:  [GET]
 
 tag_error:
   path:  /tag/error
-  defaults: { _controller: tag_controller:errorAction }
+  defaults: { _controller: tag_controller::errorAction }
 
 tag_one:
   path:  /tag/{id}
-  defaults: { _controller: tag_controller:itemAction }
+  defaults: { _controller: tag_controller::itemAction }
   methods:  [GET,POST]
 
 tag_manual:
   path: /tag_manual
-  defaults: { _controller: tag_controller:manualAction }
+  defaults: { _controller: tag_controller::manualAction }
 
 tag_twig:
   path: /tag_twig
-  defaults: { _controller: tag_controller:twigAction }
+  defaults: { _controller: tag_controller::twigAction }
 
 invalidation_route:
   path: /invalidate/route/{id}


### PR DESCRIPTION
This fixes deprecations introduced in symfony 4.1.

The changes are incompatible with older symfony versions however, we do not merge this yet.