### PR TITLE
Fix session_listener decoration when session is not enabled

### DIFF
--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -331,6 +331,7 @@ class FOSHttpCacheExtension extends Extension
         // the SessionListener to leave the cache-control header unchanged.
         if (version_compare(Kernel::VERSION, '3.4', '>=')
             && version_compare(Kernel::VERSION, '4.1', '<')
+            && $container->hasDefinition('session_listener')
         ) {
             $container->getDefinition('fos_http_cache.user_context.session_listener')
                 ->setArgument(1, strtolower($config['user_hash_header']))


### PR DESCRIPTION
#435 breaks the app when session is not used

This requires the frameworkbundle to be registered before the httpcachebundle. But might be good enough.