### PR TITLE
test response matchers

### DIFF
--- a/src/Http/ResponseMatcher/ExpressionResponseMatcher.php
+++ b/src/Http/ResponseMatcher/ExpressionResponseMatcher.php
@@ -11,7 +11,8 @@
 
 namespace FOS\HttpCacheBundle\Http\ResponseMatcher;
 
-use Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage;
+use Sensio\Bundle\FrameworkExtraBundle\Security\ExpressionLanguage as SecurityExpressionLanguage;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Response;
 
 class ExpressionResponseMatcher implements ResponseMatcherInterface
@@ -43,7 +44,10 @@ class ExpressionResponseMatcher implements ResponseMatcherInterface
     private function getExpressionLanguage()
     {
         if (!$this->expressionLanguage) {
-            $this->expressionLanguage = new ExpressionLanguage();
+            $this->expressionLanguage = class_exists(SecurityExpressionLanguage::class)
+                ? new SecurityExpressionLanguage()
+                : new ExpressionLanguage()
+            ;
         }
 
         return $this->expressionLanguage;

--- a/tests/Unit/Http/RequestMatcher/QuerystringRequestMatcherTest.php
+++ b/tests/Unit/Http/RequestMatcher/QuerystringRequestMatcherTest.php
@@ -12,14 +12,11 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\Http\RequestMatcher;
 
 use FOS\HttpCacheBundle\Http\RequestMatcher\QuerystringRequestMatcher;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 
 class QuerystringRequestMatcherTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
-
     public function testMatchesReturnsFalseIfParentCallFails()
     {
         $requestMatcher = new QuerystringRequestMatcher('/foo');

--- a/tests/Unit/Http/ResponseMatcher/CacheableResponseMatcherTest.php
+++ b/tests/Unit/Http/ResponseMatcher/CacheableResponseMatcherTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCacheBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCacheBundle\Tests\Unit\Http\ResponseMatcher;
+
+use FOS\HttpCacheBundle\Http\ResponseMatcher\CacheableResponseMatcher;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class CacheableResponseMatcherTest extends TestCase
+{
+    public function cacheableStatusCodeProvider()
+    {
+        return [
+            [200], [203], [204], [206],
+            [300], [301],
+            [404], [405], [410], [414],
+            [501],
+        ];
+    }
+
+    /**
+     * @dataProvider cacheableStatusCodeProvider
+     */
+    public function testCacheableStatus(int $status)
+    {
+        $matcher = new CacheableResponseMatcher();
+        $response = new Response('', $status);
+
+        $this->assertTrue($matcher->matches($response));
+    }
+
+    public function testNonCacheableStatus()
+    {
+        $matcher = new CacheableResponseMatcher();
+        $response = new Response('', 500);
+
+        $this->assertFalse($matcher->matches($response));
+    }
+
+    public function testCustomCacheableStatus()
+    {
+        $matcher = new CacheableResponseMatcher([400]);
+
+        $response = new Response('', 400);
+        $this->assertTrue($matcher->matches($response));
+
+        $response = new Response('', 200);
+        $this->assertTrue($matcher->matches($response));
+    }
+}

--- a/tests/Unit/Http/ResponseMatcher/ExpressionResponseMatcherTest.php
+++ b/tests/Unit/Http/ResponseMatcher/ExpressionResponseMatcherTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCacheBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCacheBundle\Tests\Unit\Http\ResponseMatcher;
+
+use FOS\HttpCacheBundle\Http\ResponseMatcher\ExpressionResponseMatcher;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
+use Symfony\Component\HttpFoundation\Response;
+
+class ExpressionResponseMatcherTest extends TestCase
+{
+    use MockeryPHPUnitIntegration;
+
+    public function testExpressionMatch()
+    {
+        $matcher = new ExpressionResponseMatcher('response.getStatusCode() === 200');
+
+        $response = new Response('', 200);
+        $this->assertTrue($matcher->matches($response));
+
+        $response = new Response('', 400);
+        $this->assertFalse($matcher->matches($response));
+    }
+
+    public function testCustomExpressionLanguage()
+    {
+        $response = new Response('', 500);
+        $el = \Mockery::mock(ExpressionLanguage::class)
+            ->shouldReceive('evaluate')
+                ->once()
+                ->with('foo === 200', ['response' => $response])->andReturnTrue()
+            ->getMock()
+        ;
+        $matcher = new ExpressionResponseMatcher('foo === 200', $el);
+
+        $this->assertTrue($matcher->matches($response));
+    }
+}

--- a/tests/Unit/Http/ResponseMatcher/NonErrorResponseMatcherTest.php
+++ b/tests/Unit/Http/ResponseMatcher/NonErrorResponseMatcherTest.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCacheBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace FOS\HttpCacheBundle\Tests\Unit\Http\ResponseMatcher;
+
+use FOS\HttpCacheBundle\Http\ResponseMatcher\NonErrorResponseMatcher;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\HttpFoundation\Response;
+
+class NonErrorResponseMatcherTest extends TestCase
+{
+    public function testSuccess()
+    {
+        $matcher = new NonErrorResponseMatcher();
+
+        $response = new Response('', 200);
+        $this->assertTrue($matcher->matches($response));
+
+        $response = new Response('', 399);
+        $this->assertTrue($matcher->matches($response));
+    }
+
+    public function testError()
+    {
+        $matcher = new NonErrorResponseMatcher();
+
+        $response = new Response('', 199);
+        $this->assertFalse($matcher->matches($response));
+
+        $response = new Response('', 400);
+        $this->assertFalse($matcher->matches($response));
+    }
+}

--- a/tests/Unit/Http/RuleMatcherTest.php
+++ b/tests/Unit/Http/RuleMatcherTest.php
@@ -13,7 +13,6 @@ namespace FOS\HttpCacheBundle\Tests\Unit\Http;
 
 use FOS\HttpCacheBundle\Http\ResponseMatcher\CacheableResponseMatcher;
 use FOS\HttpCacheBundle\Http\RuleMatcher;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcher;
@@ -21,8 +20,6 @@ use Symfony\Component\HttpFoundation\Response;
 
 class RuleMatcherTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
-
     public function testRequestMatcherCalled()
     {
         $requestMatcher = new RequestMatcher(null, null, null, null, ['_controller' => '^AcmeBundle:Default:index$']);

--- a/tests/Unit/Http/SymfonyResponseTaggerTest.php
+++ b/tests/Unit/Http/SymfonyResponseTaggerTest.php
@@ -9,25 +9,14 @@
  * file that was distributed with this source code.
  */
 
-namespace FOS\HttpCacheBundle\Tests\Unit;
+namespace FOS\HttpCacheBundle\Tests\Unit\Http;
 
-use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCacheBundle\Http\SymfonyResponseTagger;
-use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Response;
 
 class SymfonyResponseTaggerTest extends TestCase
 {
-    use MockeryPHPUnitIntegration;
-
-    private $proxyClient;
-
-    public function setUp()
-    {
-        $this->proxyClient = \Mockery::mock(ProxyClient::class);
-    }
-
     public function testTagResponse()
     {
         $tags1 = ['post-1', 'posts'];


### PR DESCRIPTION
- added unit tests
- cleanup expression matcher to allow any expression language and not just symfony framework bundle ones
- do work when optional dependency framework extra bundle is not available