### PR TITLE
Xkey Support

### DIFF
--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -29,6 +29,7 @@ varnish
         proxy_client:
             varnish:
                 tags_header: My-Cache-Tags
+                tag_mode: ban
                 header_length: 1234
                 default_ban_headers:
                     Foo: Bar
@@ -37,13 +38,6 @@ varnish
                         - 123.123.123.1:6060
                         - 123.123.123.2
                     base_url: yourwebsite.com
-
-``tags_header``
-"""""""""""""""
-
-**type**: ``string`` **default**: ``X-Cache-Tags``
-
-Header for sending tag invalidation requests to Varnish.
 
 ``header_length``
 """""""""""""""""
@@ -97,6 +91,26 @@ URL may contain a path. If you access your web application on a port other than
 
     Double-check ``base_url``, for if it is mistyped, no content will be
     invalidated.
+
+``tag_mode``
+"""""""""""""""""
+
+**type**: ``string`` **default**: ``ban``
+
+Select whether to invalidate tags using the xkey module or with ban requests. Supported modes: ``ban`` and ``purgekeys``.
+
+When using ``purgekeys`` the bundle will default to using soft purges.  If you do not want to use soft purge (either because your varnish modules version is too old to support it or because it does not fit your scenario), additionally set the tags_header option to xkey-purge instead of the default xkey-softpurge.
+
+.. note::
+
+    To use the purgekeys method, you need the `xkey vmod <https://github.com/varnish/varnish-modules/blob/master/docs/vmod_xkey.rst>`_ enabled and VCL to handle xkey invalidation requests as explained in the :ref:`FOSHttpCache library docs on xkey support <foshttpcache:varnish_tagging>`.
+
+``tags_header``
+"""""""""""""""
+
+**type**: ``string`` **default**: ``X-Cache-Tags`` if ``tag_mode`` is ``ban``, otherwise ``xkey-softpurge``
+
+Header for sending tag invalidation requests to Varnish.
 
 See the :ref:`FOSHttpCache library docs <foshttpcache:varnish configuration>`
 on how to configure Varnish.

--- a/Resources/doc/spelling_word_list.txt
+++ b/Resources/doc/spelling_word_list.txt
@@ -2,10 +2,12 @@ admin
 backend
 cacheable
 ETag
+friendsofsymfony
 github
 hostname
 invalidations
 invalidator
+javascript
 login
 logout
 lookup
@@ -16,10 +18,14 @@ multi
 nginx
 noop
 Packagist
+plugin
 preflight
+purgekeys
 redeclaration
+softpurge
 symfony
 subdomains
 templating
 TTL
+xkey
 yaml

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -474,6 +474,7 @@ class FOSHttpCacheExtension extends Extension
 
         $container->setParameter('fos_http_cache.compiler_pass.tag_annotations', true);
         $container->setParameter('fos_http_cache.tag_handler.response_header', $config['response_header']);
+        $container->setParameter('fos_http_cache.tag_handler.separator', $config['separator']);
         $container->setParameter('fos_http_cache.tag_handler.strict', $config['strict']);
 
         $loader->load('cache_tagging.xml');

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -477,17 +477,10 @@ class FOSHttpCacheExtension extends Extension
             throw new InvalidConfigurationException(sprintf('You can not enable cache tagging with the %s client', $client));
         }
 
-<<<<<<< HEAD
         $container->setParameter('fos_http_cache.compiler_pass.tag_annotations', true);
         $container->setParameter('fos_http_cache.tag_handler.response_header', $config['response_header']);
         $container->setParameter('fos_http_cache.tag_handler.strict', $config['strict']);
-=======
-        $container->setParameter($this->getAlias().'.compiler_pass.tag_annotations', true);
-        $container->setParameter($this->getAlias().'.tag_handler.strict', $config['strict']);
-        $container->setParameter($this->getAlias().'.tag_handler.response_header', $config['response_header']);
-        $container->setParameter($this->getAlias().'.tag_handler.separator', $config['separator']);
 
->>>>>>> Added configuration setting for enabling xkey tagging
         $loader->load('cache_tagging.xml');
         if (class_exists(Application::class)) {
             $loader->load('cache_tagging_commands.xml');

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\DependencyInjection;
 
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use FOS\HttpCache\ProxyClient\ProxyClient;
+use FOS\HttpCache\ProxyClient\Varnish;
 use FOS\HttpCache\SymfonyCache\KernelDispatcher;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use FOS\HttpCacheBundle\Http\ResponseMatcher\ExpressionResponseMatcher;
@@ -403,15 +404,22 @@ class FOSHttpCacheExtension extends Extension
     {
         $this->createHttpDispatcherDefinition($container, $config['http'], 'fos_http_cache.proxy_client.varnish.http_dispatcher');
         $options = [
+            'tag_mode' => $config['tag_mode'],
             'tags_header' => $config['tags_header'],
         ];
+
         if (!empty($config['header_length'])) {
             $options['header_length'] = $config['header_length'];
         }
         if (!empty($config['default_ban_headers'])) {
             $options['default_ban_headers'] = $config['default_ban_headers'];
         }
+<<<<<<< HEAD
         $container->setParameter('fos_http_cache.proxy_client.varnish.options', $options);
+=======
+
+        $container->setParameter($this->getAlias().'.proxy_client.varnish.options', $options);
+>>>>>>> Added configuration setting for enabling xkey tagging
 
         $loader->load('varnish.xml');
     }
@@ -469,9 +477,17 @@ class FOSHttpCacheExtension extends Extension
             throw new InvalidConfigurationException(sprintf('You can not enable cache tagging with the %s client', $client));
         }
 
+<<<<<<< HEAD
         $container->setParameter('fos_http_cache.compiler_pass.tag_annotations', true);
         $container->setParameter('fos_http_cache.tag_handler.response_header', $config['response_header']);
         $container->setParameter('fos_http_cache.tag_handler.strict', $config['strict']);
+=======
+        $container->setParameter($this->getAlias().'.compiler_pass.tag_annotations', true);
+        $container->setParameter($this->getAlias().'.tag_handler.strict', $config['strict']);
+        $container->setParameter($this->getAlias().'.tag_handler.response_header', $config['response_header']);
+        $container->setParameter($this->getAlias().'.tag_handler.separator', $config['separator']);
+
+>>>>>>> Added configuration setting for enabling xkey tagging
         $loader->load('cache_tagging.xml');
         if (class_exists(Application::class)) {
             $loader->load('cache_tagging_commands.xml');

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -414,13 +414,8 @@ class FOSHttpCacheExtension extends Extension
         if (!empty($config['default_ban_headers'])) {
             $options['default_ban_headers'] = $config['default_ban_headers'];
         }
-<<<<<<< HEAD
+
         $container->setParameter('fos_http_cache.proxy_client.varnish.options', $options);
-=======
-
-        $container->setParameter($this->getAlias().'.proxy_client.varnish.options', $options);
->>>>>>> Added configuration setting for enabling xkey tagging
-
         $loader->load('varnish.xml');
     }
 

--- a/src/Resources/config/cache_tagging.xml
+++ b/src/Resources/config/cache_tagging.xml
@@ -7,6 +7,7 @@
     <services>
         <service id="fos_http_cache.tag_handler.header_formatter" class="FOS\HttpCache\TagHeaderFormatter\CommaSeparatedTagHeaderFormatter" public="false">
             <argument>%fos_http_cache.tag_handler.response_header%</argument>
+            <argument>%fos_http_cache.tag_handler.separator%</argument>
         </service>
 
         <service id="fos_http_cache.http.symfony_response_tagger" class="FOS\HttpCacheBundle\Http\SymfonyResponseTagger" public="true">

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -94,6 +94,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             ],
             'proxy_client' => [
                 'varnish' => [
+                    'tag_mode' => 'ban',
                     'tags_header' => 'My-Cache-Tags',
                     'header_length' => 1234,
                     'default_ban_headers' => ['Foo' => 'Bar'],
@@ -130,6 +131,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         'tag_expressions' => ['"a"', '"b"'],
                     ],
                 ],
+                'separator' => ',',
             ],
             'invalidation' => [
                 'enabled' => 'auto',
@@ -385,6 +387,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'servers' => ['1.1.1.1:80', '2.2.2.2:80'],
                 ],
                 'tags_header' => 'X-Cache-Tags',
+                'tag_mode' => 'ban',
             ],
             'nginx' => [
                 'purge_location' => false,
@@ -685,6 +688,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'response_header' => 'X-Cache-Tags',
                 'expression_language' => null,
                 'rules' => [],
+                'separator' => ',',
             ],
             'invalidation' => [
                 'enabled' => false,

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -546,6 +546,55 @@ class FOSHttpCacheExtensionTest extends TestCase
         $this->assertTrue($container->has('fos_http_cache.event_listener.flash_message'));
     }
 
+    public function testVarnishDefaultTagMode()
+    {
+        $container = $this->createContainer();
+
+        $config = $this->getBaseConfig();
+        $this->extension->load([$config], $container);
+
+        $this->assertEquals('X-Cache-Tags', $container->getParameter('fos_http_cache.tag_handler.response_header'));
+        $this->assertEquals(',', $container->getParameter('fos_http_cache.tag_handler.separator'));
+        $this->assertEquals(['tag_mode' => 'ban', 'tags_header' => 'X-Cache-Tags'], $container->getParameter('fos_http_cache.proxy_client.varnish.options'));
+    }
+
+    public function testVarnishBanTagMode()
+    {
+        $container = $this->createContainer();
+
+        $config = $this->getBaseConfig();
+        $config['proxy_client']['varnish']['tag_mode'] = 'ban';
+        $this->extension->load([$config], $container);
+
+        $this->assertEquals('X-Cache-Tags', $container->getParameter('fos_http_cache.tag_handler.response_header'));
+        $this->assertEquals(',', $container->getParameter('fos_http_cache.tag_handler.separator'));
+        $this->assertEquals(['tag_mode' => 'ban', 'tags_header' => 'X-Cache-Tags'], $container->getParameter('fos_http_cache.proxy_client.varnish.options'));
+    }
+
+    public function testVarnishXkeyTagMode()
+    {
+        $container = $this->createContainer();
+
+        $config = $this->getBaseConfig();
+        $config['proxy_client']['varnish']['tag_mode'] = 'purgekeys';
+        $this->extension->load([$config], $container);
+
+        $this->assertEquals('xkey', $container->getParameter('fos_http_cache.tag_handler.response_header'));
+        $this->assertEquals(' ', $container->getParameter('fos_http_cache.tag_handler.separator'));
+        $this->assertEquals(['tag_mode' => 'purgekeys', 'tags_header' => 'xkey-softpurge'], $container->getParameter('fos_http_cache.proxy_client.varnish.options'));
+    }
+
+    public function testVarnishCustomTagsHeader()
+    {
+        $container = $this->createContainer();
+
+        $config = $this->getBaseConfig();
+        $config['proxy_client']['varnish']['tags_header'] = 'myheader';
+        $this->extension->load([$config], $container);
+
+        $this->assertEquals(['tag_mode' => 'ban', 'tags_header' => 'myheader'], $container->getParameter('fos_http_cache.proxy_client.varnish.options'));
+    }
+
     private function createContainer()
     {
         $container = new ContainerBuilder(


### PR DESCRIPTION
This PR adds support for tagging and invalidating items using Varnish's xkey mode. (#431)

Enabling xkey based tagging and invalidating is done by setting the `fos_http_cache.proxy_client.varnish.tag_mode` setting to `purgekeys`.  Doing so will update the tag_handler to use the `xkey` response header, and to separate tags using a space instead of a comma.  It will also pass the `tag_mode` setting to the FOS http-cache library, which takes care of sending the correct response headers on invalidation requests.

Setting a custom `tags_header` setting is also supported (for switching between `xkey-softpurge` and `xkey-purge`, or a custom one).

If these changes all make sense I'll update the documentation too.