### PR TITLE
Documentation Fix: header -> response_header

### DIFF
--- a/Resources/doc/reference/configuration/tags.rst
+++ b/Resources/doc/reference/configuration/tags.rst
@@ -30,7 +30,7 @@ incompatible proxies:
         tags:
             enabled: true
 
-``header``
+``response_header``
 ----------
 
 **type**: ``string`` **default**: ``X-Cache-Tags``


### PR DESCRIPTION
Fix documentation to reflect the fact the setting is called response_header and not header