### PR TITLE
Autoconfigure custom context providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ Changelog
 
 ### Added
 
+* Autoconfigure support for custom context providers.
+
 * Autowiring support for the services in this bundle:
 
   - fos_http_cache.cache_manager => FOS\HttpCacheBundle\CacheManager

--- a/Resources/doc/reference/configuration/user-context.rst
+++ b/Resources/doc/reference/configuration/user-context.rst
@@ -231,6 +231,13 @@ Custom providers need to:
 * implement the ``FOS\HttpCache\UserContext\ContextProvider`` interface
 * be tagged with ``fos_http_cache.user_context_provider``.
 
+.. versionadded:: 2.4.0
+    Autoconfigure support has been added in version 2.4.0 and works from
+    Symfony 3.3 and above. If autoconfigure is enabled, your custom provider
+    will be tagged automatically, with a default priority of 0. For older
+    versions, or if autoconfigure is disabled, or you want to override the
+    priority, check out the section below.
+
 If you need context providers to run in a specific order, you can specify the
 optional ``priority`` parameter for the tag. The higher the priority, the
 earlier a context provider is executed. The build-in provider has a priority

--- a/src/FOSHttpCacheBundle.php
+++ b/src/FOSHttpCacheBundle.php
@@ -11,6 +11,7 @@
 
 namespace FOS\HttpCacheBundle;
 
+use FOS\HttpCache\UserContext\ContextProvider;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\LoggerPass;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\SessionListenerRemovePass;
@@ -34,6 +35,13 @@ class FOSHttpCacheBundle extends Bundle
             && version_compare(Kernel::VERSION, '4.1', '<')
         ) {
             $container->addCompilerPass(new SessionListenerRemovePass());
+        }
+
+        // Symfony 3.3 and higher
+        if (method_exists($container, 'registerForAutoconfiguration')) {
+            $container
+                ->registerForAutoconfiguration(ContextProvider::class)
+                ->addTag('fos_http_cache.user_context_provider');
         }
     }
 


### PR DESCRIPTION
This would reduce some configuration. Right now we can autoconfigure almost all services, except our custom context provider.