### PR TITLE
Add SessionListener::onFinishRequest method to be inline with Symfony 3.4.12

### DIFF
--- a/EventListener/SessionListener.php
+++ b/EventListener/SessionListener.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\SessionListener as BaseSessionListener;
 
@@ -76,6 +77,13 @@ final class SessionListener implements EventSubscriberInterface
         }
 
         // noop, see class description
+    }
+
+    public function onFinishRequest(FinishRequestEvent $event)
+    {
+        if (method_exists($this->inner, 'onFinishRequest')) {
+            $this->inner->onFinishRequest($event);
+        }
     }
 
     public static function getSubscribedEvents()

--- a/Tests/Unit/EventListener/SessionListenerTest.php
+++ b/Tests/Unit/EventListener/SessionListenerTest.php
@@ -47,6 +47,28 @@ class SessionListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
+    public function testOnFinishRequestRemainsUntouched()
+    {
+        $event = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Event\FinishRequestEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $inner = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\EventListener\SessionListener')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $inner
+            ->expects($this->once())
+            ->method('onFinishRequest')
+            ->with($event)
+        ;
+
+        $listener = $this->getListener($inner);
+        $listener->onFinishRequest($event);
+    }
+
     /**
      * @dataProvider onKernelResponseProvider
      */

--- a/Tests/Unit/EventListener/SessionListenerTest.php
+++ b/Tests/Unit/EventListener/SessionListenerTest.php
@@ -49,6 +49,10 @@ class SessionListenerTest extends TestCase
 
     public function testOnFinishRequestRemainsUntouched()
     {
+        if (!method_exists('Symfony\Component\HttpKernel\EventListener\SessionListener', 'onFinishRequest')) {
+            $this->markTestSkipped('Method onFinishRequest does not exist on Symfony\Component\HttpKernel\EventListener\SessionListener');
+        }
+
         $event = $this
             ->getMockBuilder('Symfony\Component\HttpKernel\Event\FinishRequestEvent')
             ->disableOriginalConstructor()


### PR DESCRIPTION
Fixes #465 

Same issue is probably happening on master, so needs to be forward ported.