### PR TITLE
Add SessionListener::onFinishRequest method to work with Symfony 3.4.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.3.16
+------
+
+* Adjust session_listener to work with Symfony 3.4.12 (https://github.com/symfony/symfony/pull/27467).
+
 1.3.15
 ------
 

--- a/EventListener/SessionListener.php
+++ b/EventListener/SessionListener.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\SessionListener as BaseSessionListener;
 
@@ -76,6 +77,12 @@ final class SessionListener implements EventSubscriberInterface
         }
 
         // noop, see class description
+    }
+
+    public function onFinishRequest(FinishRequestEvent $event)
+    {
+        // this hook has been added in symfony 3.4.12 - older versions of the listener do not register for it
+        $this->inner->onFinishRequest($event);
     }
 
     public static function getSubscribedEvents()

--- a/Tests/Unit/EventListener/SessionListenerTest.php
+++ b/Tests/Unit/EventListener/SessionListenerTest.php
@@ -47,6 +47,32 @@ class SessionListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
+    public function testOnFinishRequestRemainsUntouched()
+    {
+        if (!method_exists('Symfony\Component\HttpKernel\EventListener\SessionListener', 'onFinishRequest')) {
+            $this->markTestSkipped('Method onFinishRequest does not exist on Symfony\Component\HttpKernel\EventListener\SessionListener');
+        }
+
+        $event = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Event\FinishRequestEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $inner = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\EventListener\SessionListener')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $inner
+            ->expects($this->once())
+            ->method('onFinishRequest')
+            ->with($event)
+        ;
+
+        $listener = $this->getListener($inner);
+        $listener->onFinishRequest($event);
+    }
+
     /**
      * @dataProvider onKernelResponseProvider
      */


### PR DESCRIPTION
wrap up #466