### PR TITLE
Fixed dependency error, update master from 1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,11 @@ access to other services.)
 * Added an option `always_vary_on_context_hash` to make it possible to disable 
   automatically setting the vary headers for the user hash.
 
+1.3.16
+------
+
+* Adjust session_listener to work with Symfony 3.4.12 (https://github.com/symfony/symfony/pull/27467).
+
 1.3.15
 ------
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+2.4.1
+-----
+
+* Adjust session_listener to work with Symfony 3.4.12 (https://github.com/symfony/symfony/pull/27467).
+
 2.4.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
         "symfony/css-selector": "^2.8.18||^3.3||^4.0",
         "symfony/expression-language": "^2.8.18||^3.3||^4.0",
         "symfony/monolog-bundle": "^2.8.18||^3.3||^4.0",
+        "symfony/routing": "^2.8.18||^3.3||^4.0",
         "matthiasnoback/symfony-dependency-injection-test": "^2.3",
         "sebastian/exporter": "^2.0"
     },

--- a/src/EventListener/SessionListener.php
+++ b/src/EventListener/SessionListener.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
+use Symfony\Component\HttpKernel\Event\FinishRequestEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
 use Symfony\Component\HttpKernel\EventListener\SessionListener as BaseSessionListener;
 
@@ -81,7 +82,13 @@ final class SessionListener implements EventSubscriberInterface
         // noop, see class description
     }
 
-    public static function getSubscribedEvents(): array
+    public function onFinishRequest(FinishRequestEvent $event)
+    {
+        // this hook has been added in symfony 3.4.12 - older versions of the listener do not register for it
+        $this->inner->onFinishRequest($event);
+    }
+
+    public static function getSubscribedEvents()
     {
         return BaseSessionListener::getSubscribedEvents();
     }

--- a/src/EventListener/SessionListener.php
+++ b/src/EventListener/SessionListener.php
@@ -88,7 +88,7 @@ final class SessionListener implements EventSubscriberInterface
         $this->inner->onFinishRequest($event);
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return BaseSessionListener::getSubscribedEvents();
     }

--- a/tests/Unit/EventListener/SessionListenerTest.php
+++ b/tests/Unit/EventListener/SessionListenerTest.php
@@ -38,6 +38,32 @@ class SessionListenerTest extends TestCase
         $listener->onKernelRequest($event);
     }
 
+    public function testOnFinishRequestRemainsUntouched()
+    {
+        if (!method_exists('Symfony\Component\HttpKernel\EventListener\SessionListener', 'onFinishRequest')) {
+            $this->markTestSkipped('Method onFinishRequest does not exist on Symfony\Component\HttpKernel\EventListener\SessionListener');
+        }
+
+        $event = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\Event\FinishRequestEvent')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $inner = $this
+            ->getMockBuilder('Symfony\Component\HttpKernel\EventListener\SessionListener')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $inner
+            ->expects($this->once())
+            ->method('onFinishRequest')
+            ->with($event)
+        ;
+
+        $listener = $this->getListener($inner);
+        $listener->onFinishRequest($event);
+    }
+
     /**
      * @dataProvider onKernelResponseProvider
      */


### PR DESCRIPTION
```
    - symfony/lts v3 conflicts with symfony/routing[4.1.x-dev].
    - symfony/lts v3 conflicts with symfony/routing[v4.1.0].
    - symfony/lts v3 conflicts with symfony/routing[v4.1.0-BETA1].
    - symfony/lts v3 conflicts with symfony/routing[v4.1.0-BETA2].
    - symfony/lts v3 conflicts with symfony/routing[v4.1.0-BETA3].
    - symfony/lts v3 conflicts with symfony/routing[v4.1.1].
    - symfony/lts v3 conflicts with symfony/routing[v4.1.2].
    - symfony/lts v3 conflicts with symfony/routing[v4.1.3].
    - Installation request for symfony/lts ^3 -> satisfiable by symfony/lts[v3].
    - Installation request for symfony/routing 4.1.*@dev -> satisfiable by symfony/routing[4.1.x-dev, v4.1.0, v4.1.0-BETA1, v4.1.0-BETA2, v4.1.0-BETA3, v4.1.1, v4.1.2, v4.1.3].
```

Closes https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/473