### PR TITLE
Fix missing NoAutoCacheControl when vary on contex hash is set from Response

### DIFF
--- a/src/EventListener/UserContextListener.php
+++ b/src/EventListener/UserContextListener.php
@@ -198,10 +198,12 @@ class UserContextListener implements EventSubscriberInterface
                 && !in_array($this->options['user_hash_header'], $vary)
             ) {
                 $vary[] = $this->options['user_hash_header'];
-                if (4 <= Kernel::MAJOR_VERSION && 1 <= Kernel::MINOR_VERSION) {
-                    // header to avoid Symfony SessionListener overwriting the response to private
-                    $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 1);
-                }
+            }
+
+            // For Symfony 4.1+ if user hash header was in vary or just added here by "add_vary_on_hash"
+            if (4 <= Kernel::MAJOR_VERSION && 1 <= Kernel::MINOR_VERSION && in_array($this->options['user_hash_header'], $vary)) {
+                // header to avoid Symfony SessionListener overwriting the response to private
+                $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 1);
             }
         } elseif ($this->options['add_vary_on_hash']) {
             /*

--- a/tests/Unit/EventListener/UserContextListenerTest.php
+++ b/tests/Unit/EventListener/UserContextListenerTest.php
@@ -18,9 +18,9 @@ use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
 use Symfony\Component\HttpKernel\Event\GetResponseEvent;
+use Symfony\Component\HttpKernel\EventListener\AbstractSessionListener;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
 use Symfony\Component\HttpKernel\Kernel;
 
@@ -187,7 +187,7 @@ class UserContextListenerTest extends TestCase
     public function testOnKernelResponseSetsNoAutoCacheHeader()
     {
         if (4 > Kernel::MAJOR_VERSION || 1 > Kernel::MINOR_VERSION) {
-            $this->markTestSkipped("Test only relevant for Symfony 4.1 and up");
+            $this->markTestSkipped('Test only relevant for Symfony 4.1 and up');
         }
 
         $request = new Request();
@@ -211,7 +211,7 @@ class UserContextListenerTest extends TestCase
     public function testOnKernelResponseSetsNoAutoCacheHeaderWhenCustomHeader()
     {
         if (4 > Kernel::MAJOR_VERSION || 1 > Kernel::MINOR_VERSION) {
-            $this->markTestSkipped("Test only relevant for Symfony 4.1 and up");
+            $this->markTestSkipped('Test only relevant for Symfony 4.1 and up');
         }
 
         $request = new Request();
@@ -234,7 +234,7 @@ class UserContextListenerTest extends TestCase
     public function testOnKernelResponseSetsNoAutoCacheHeaderWhenCustomHeaderAndNoAddVaryOnHash()
     {
         if (4 > Kernel::MAJOR_VERSION || 1 > Kernel::MINOR_VERSION) {
-            $this->markTestSkipped("Test only relevant for Symfony 4.1 and up");
+            $this->markTestSkipped('Test only relevant for Symfony 4.1 and up');
         }
 
         $request = new Request();
@@ -248,7 +248,7 @@ class UserContextListenerTest extends TestCase
             $hashGenerator,
             null,
             [
-                'add_vary_on_hash' => false
+                'add_vary_on_hash' => false,
             ]
         );
         $event = $this->getKernelResponseEvent($request, new Response('', 200, ['Vary' => 'X-User-Context-Hash']));
@@ -261,7 +261,7 @@ class UserContextListenerTest extends TestCase
     public function testOnKernelResponseDoesNotSetNoAutoCacheHeaderWhenNoCustomHeaderAndNoAddVaryOnHash()
     {
         if (4 > Kernel::MAJOR_VERSION || 1 > Kernel::MINOR_VERSION) {
-            $this->markTestSkipped("Test only relevant for Symfony 4.1 and up");
+            $this->markTestSkipped('Test only relevant for Symfony 4.1 and up');
         }
 
         $request = new Request();
@@ -275,7 +275,7 @@ class UserContextListenerTest extends TestCase
             $hashGenerator,
             null,
             [
-                'add_vary_on_hash' => false
+                'add_vary_on_hash' => false,
             ]
         );
         $event = $this->getKernelResponseEvent($request);


### PR DESCRIPTION
This moves logic to set NoAutoCacheControl so it is always executed if
vary header exists, now also when that is the case from response already.

Also adds unit test coverage for this feature.