### PR TITLE
clear response tagger after tagging to not leak tags from one response to the next

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 Changelog
 =========
 
+2.5.1 (unreleased)
+------------------
+
+### Fixed
+
+* Cache Tagging: Clear the SymfonyResponseTagger after we tagged a response.
+  Usually PHP uses a new instance for every request. But for example the hash
+  lookup when using Symfony HttpCache does two requests in the same PHP
+  process.
+
 2.5.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "friendsofsymfony/http-cache": "^2.5",
+        "friendsofsymfony/http-cache": "^2.5.2",
         "symfony/framework-bundle": "^3.4.4 || ^4.0",
         "symfony/http-foundation": "^3.4.4 || ^4.0",
         "symfony/http-kernel": "^3.4.4 || ^4.0"

--- a/src/Http/SymfonyResponseTagger.php
+++ b/src/Http/SymfonyResponseTagger.php
@@ -40,6 +40,7 @@ class SymfonyResponseTagger extends ResponseTagger
         }
 
         $response->headers->set($this->getTagsHeaderName(), $this->getTagsHeaderValue());
+        $this->clear();
 
         return $this;
     }

--- a/tests/Unit/Http/SymfonyResponseTaggerTest.php
+++ b/tests/Unit/Http/SymfonyResponseTaggerTest.php
@@ -30,6 +30,7 @@ class SymfonyResponseTaggerTest extends TestCase
         $symfonyResponseTagger1->tagSymfonyResponse($response);
         $this->assertTrue($response->headers->has('X-Cache-Tags'));
         $this->assertEquals(implode(',', $tags1), $response->headers->get('X-Cache-Tags'));
+        $this->assertFalse($symfonyResponseTagger1->hasTags());
 
         $symfonyResponseTagger2 = new SymfonyResponseTagger();
         $symfonyResponseTagger2->addTags($tags2);


### PR DESCRIPTION
requires https://github.com/FriendsOfSymfony/FOSHttpCache/pull/430 and a new patch release of the library.