### PR TITLE
Added link to symfony httpcache docs for http_method_override

### DIFF
--- a/Resources/doc/features/symfony-http-cache.rst
+++ b/Resources/doc/features/symfony-http-cache.rst
@@ -98,8 +98,7 @@ your kernel like this::
         }
     }
 
-Now you need to adjust your front controller to use that cache instance rather
-than creating one::
+Now you need to adjust your front controller (that you set up according to the `Symfony HttpCache documentation_`) to use that cache instance rather than creating one::
 
     // public/index.php
 
@@ -111,6 +110,8 @@ than creating one::
     if ('prod' === $env) {
         $kernel = $kernel->getHttpCache();
     }
+
+    // ...
 
 .. warning::
 


### PR DESCRIPTION
Based on the symfony docs enable method override is enabled by default so we should also add Request:: enableHttpMethodParameterOverride() by default?

https://symfony.com/doc/current/reference/configuration/framework.html#http-method-override