### PR TITLE
Fix readthedocs code highlighting

### DIFF
--- a/Resources/doc/conf.py
+++ b/Resources/doc/conf.py
@@ -28,6 +28,7 @@ extensions = [
     'sphinx.ext.coverage',
     'sphinx.ext.todo',
     'sensio.sphinx.configurationblock',
+    'sphinxcontrib.phpdomain',
     'sphinxcontrib.spelling'
 ]
 

--- a/Resources/doc/requirements.txt
+++ b/Resources/doc/requirements.txt
@@ -1,4 +1,5 @@
 git+https://github.com/fabpot/sphinx-php.git
 sphinx-rtd-theme==0.1.6
 sphinxcontrib-spelling
+sphinxcontrib.phpdomain
 pyenchant


### PR DESCRIPTION
This should hopelly fix the code highlighting in the docs:
based on: https://github.com/sphinx-doc/sphinx/issues/3215#issuecomment-368623135