### PR TITLE
Fix requirements sphinxcontrib-phpdomain and use newest rtd theme

### DIFF
--- a/Resources/doc/conf.py
+++ b/Resources/doc/conf.py
@@ -100,7 +100,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/Resources/doc/conf.py
+++ b/Resources/doc/conf.py
@@ -27,8 +27,9 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.coverage',
     'sphinx.ext.todo',
-    'sensio.sphinx.configurationblock',
     'sphinxcontrib.phpdomain',
+    'sensio.sphinx.configurationblock',
+    'sensio.sphinx.phpcode',
     'sphinxcontrib.spelling'
 ]
 

--- a/Resources/doc/conf.py
+++ b/Resources/doc/conf.py
@@ -51,7 +51,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'FOSHttpCacheBundle'
-copyright = '2014-2017, David de Boer, David Buchmann'
+copyright = '2014-2018, David de Boer, David Buchmann'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/Resources/doc/conf.py
+++ b/Resources/doc/conf.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 #
 
-import sys, os
+import sys, os, sphinx_rtd_theme
 from sphinx.highlighting import lexers
 from pygments.lexers.web import PhpLexer
 
@@ -109,7 +109,7 @@ html_theme = 'sphinx_rtd_theme'
 #html_theme_options = {}
 
 # Add any paths that contain custom themes here, relative to this directory.
-#html_theme_path = []
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".

--- a/Resources/doc/requirements.txt
+++ b/Resources/doc/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/fabpot/sphinx-php.git
-sphinx-rtd-theme==0.1.6
+sphinx-rtd-theme
 sphinxcontrib-spelling
-sphinxcontrib.phpdomain
+sphinxcontrib-phpdomain
 pyenchant

--- a/Resources/doc/requirements.txt
+++ b/Resources/doc/requirements.txt
@@ -1,5 +1,5 @@
 git+https://github.com/fabpot/sphinx-php.git
-sphinx-rtd-theme
+sphinx_rtd_theme
 sphinxcontrib-spelling
 sphinxcontrib-phpdomain
 pyenchant


### PR DESCRIPTION
#495 did not fix the code highlighting

 - add `sphinxcontrib-phpdomain` as correct requirements
 - update `sphinx_rtd_theme` and use it in the ci
 - activate `phpdoc` from sensio