### PR TITLE
test with httplug 2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Changelog
 
 * Adjusted to work with Twig 3
 * Adjusted to work with Symfony 5
+* Allow Httplug 2
 
 2.7.2
 -----

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0 || ^2.0",
-        "php-http/message": "^1.0",
-        "mockery/mockery": "^1.0",
+        "php-http/message": "^1.0 || ^2.0",
+        "mockery/mockery": "^1.0 || ^2.0",
         "monolog/monolog": "*",
         "sensio/framework-extra-bundle": "^3.0 || ^4.0 || ^5.0",
         "symfony/browser-kit": "^3.4.4 || ^4.1.12 || ^5.0",


### PR DESCRIPTION
lets wait with merging until php-http/client-common has a 2.0 release and we see php-http/guzzle6-adapter 2.0 being installed in the travis build.

also needs https://github.com/FriendsOfSymfony/FOSHttpCache/pull/442 merged and tagged first.