### PR TITLE
do not leak the Symfony-Session-NoAutoCacheControl header when the Symfony session system is not enabled.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.6.1
+-----
+
+### Fixed
+
+* Do not leak the `Symfony-Session-NoAutoCacheControl` header when the Symfony session system is not enabled.
+
 2.6.0
 -----
 

--- a/src/FOSHttpCacheBundle.php
+++ b/src/FOSHttpCacheBundle.php
@@ -14,7 +14,7 @@ namespace FOS\HttpCacheBundle;
 use FOS\HttpCache\UserContext\ContextProvider;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\LoggerPass;
-use FOS\HttpCacheBundle\DependencyInjection\Compiler\SessionListenerRemovePass;
+use FOS\HttpCacheBundle\DependencyInjection\Compiler\SessionListenerPass;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\TagListenerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
@@ -33,7 +33,7 @@ class FOSHttpCacheBundle extends Bundle
         if (version_compare(Kernel::VERSION, '3.4', '>=')
             && version_compare(Kernel::VERSION, '4.1', '<')
         ) {
-            $container->addCompilerPass(new SessionListenerRemovePass());
+            $container->addCompilerPass(new SessionListenerPass());
         }
 
         // Symfony 3.3 and higher

--- a/src/Resources/config/user_context.xml
+++ b/src/Resources/config/user_context.xml
@@ -19,6 +19,7 @@
             <argument type="service" id="fos_http_cache.user_context.anonymous_request_matcher" />
             <argument type="service" id="fos_http_cache.http.symfony_response_tagger" on-invalid="ignore" />
             <argument>%fos_http_cache.event_listener.user_context.options%</argument>
+            <argument>true</argument>
             <tag name="kernel.event_subscriber" />
         </service>
 

--- a/tests/Unit/EventListener/UserContextListenerTest.php
+++ b/tests/Unit/EventListener/UserContextListenerTest.php
@@ -203,7 +203,7 @@ class UserContextListenerTest extends TestCase
 
     public function testOnKernelResponseSetsNoAutoCacheHeader()
     {
-        if (4 > Kernel::MAJOR_VERSION || 1 > Kernel::MINOR_VERSION) {
+        if (\version_compare('4.1', Kernel::VERSION, '>')) {
             $this->markTestSkipped('Test only relevant for Symfony 4.1 and up');
         }
 
@@ -225,9 +225,37 @@ class UserContextListenerTest extends TestCase
         $this->assertEquals(1, $event->getResponse()->headers->get(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
     }
 
+    public function testOnKernelResponseDoesNotSetNoAutoCacheHeaderWhenNoSessionListener()
+    {
+        if (\version_compare('4.1', Kernel::VERSION, '>')) {
+            $this->markTestSkipped('Test only relevant for Symfony 4.1 and up');
+        }
+
+        $request = new Request();
+        $request->setMethod('HEAD');
+        $request->headers->set('X-User-Context-Hash', 'hash');
+
+        $hashGenerator = \Mockery::mock(HashGenerator::class);
+
+        $userContextListener = new UserContextListener(
+            $this->getRequestMatcher($request, false),
+            $hashGenerator,
+            null,
+            null,
+            [],
+            false
+        );
+        $event = $this->getKernelResponseEvent($request);
+
+        $userContextListener->onKernelResponse($event);
+
+        $this->assertContains('X-User-Context-Hash', $event->getResponse()->headers->get('Vary'));
+        $this->assertFalse($event->getResponse()->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
+    }
+
     public function testOnKernelResponseSetsNoAutoCacheHeaderWhenCustomHeader()
     {
-        if (4 > Kernel::MAJOR_VERSION || 1 > Kernel::MINOR_VERSION) {
+        if (\version_compare('4.1', Kernel::VERSION, '>')) {
             $this->markTestSkipped('Test only relevant for Symfony 4.1 and up');
         }
 
@@ -250,7 +278,7 @@ class UserContextListenerTest extends TestCase
 
     public function testOnKernelResponseSetsNoAutoCacheHeaderWhenCustomHeaderAndNoAddVaryOnHash()
     {
-        if (4 > Kernel::MAJOR_VERSION || 1 > Kernel::MINOR_VERSION) {
+        if (\version_compare('4.1', Kernel::VERSION, '>')) {
             $this->markTestSkipped('Test only relevant for Symfony 4.1 and up');
         }
 
@@ -278,7 +306,7 @@ class UserContextListenerTest extends TestCase
 
     public function testOnKernelResponseDoesNotSetNoAutoCacheHeaderWhenNoCustomHeaderAndNoAddVaryOnHash()
     {
-        if (4 > Kernel::MAJOR_VERSION || 1 > Kernel::MINOR_VERSION) {
+        if (\version_compare('4.1', Kernel::VERSION, '>')) {
             $this->markTestSkipped('Test only relevant for Symfony 4.1 and up');
         }
 


### PR DESCRIPTION
fix #512