### PR TITLE
cleanup command service definition

### DIFF
--- a/src/Resources/config/cache_manager_commands.xml
+++ b/src/Resources/config/cache_manager_commands.xml
@@ -8,12 +8,12 @@
 
         <service id="fos_http_cache.command.invalidate_path" class="FOS\HttpCacheBundle\Command\InvalidatePathCommand">
             <argument type="service" id="fos_http_cache.cache_manager" />
-            <tag name="console.command" command="fos:httpcache:invalidate:path"/>
+            <tag name="console.command"/>
         </service>
 
         <service id="fos_http_cache.command.invalidate_regex" class="FOS\HttpCacheBundle\Command\InvalidateRegexCommand">
             <argument type="service" id="fos_http_cache.cache_manager" />
-            <tag name="console.command" command="fos:httpcache:invalidate:regex"/>
+            <tag name="console.command"/>
         </service>
 
         <service id="fos_http_cache.command.refresh_path" class="FOS\HttpCacheBundle\Command\RefreshPathCommand">


### PR DESCRIPTION
no need to specify the command names in the config file anymore, we use the static property now.