### PR TITLE
Do not validate configuration when environment parameters are used

### DIFF
--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -375,11 +375,20 @@ class FOSHttpCacheExtension extends Extension
     private function createHttpDispatcherDefinition(ContainerBuilder $container, array $config, $serviceName)
     {
         foreach ($config['servers'] as $url) {
-            $this->validateUrl($url, 'Not a valid Varnish server address: "%s"');
+            $usedEnvs = [];
+            $container->resolveEnvPlaceholders($url, null, $usedEnvs);
+            if (0 === \count($usedEnvs)) {
+                $this->validateUrl($url, 'Not a valid Varnish server address: "%s"');
+            }
         }
         if (!empty($config['base_url'])) {
-            $baseUrl = $this->prefixSchema($config['base_url']);
-            $this->validateUrl($baseUrl, 'Not a valid base path: "%s"');
+            $baseUrl = $config['base_url'];
+            $usedEnvs = [];
+            $container->resolveEnvPlaceholders($baseUrl, null, $usedEnvs);
+            if (0 === \count($usedEnvs)) {
+                $baseUrl = $this->prefixSchema($baseUrl);
+                $this->validateUrl($baseUrl, 'Not a valid base path: "%s"');
+            }
         } else {
             $baseUrl = null;
         }


### PR DESCRIPTION
Related to #521 

allow things like 
```
parameters:
  env(VARNISH_SERVER): "varnish1.test"
  env(VARNISH_BASE_URL): "site.test"

fos_http_cache:
    proxy_client:
        varnish:
            http: 
                servers: ['%env(json:VARNISH_HTTP)%']
                base_url: '%env(json:VARNISH_BASE_URL)%'
```