### PR TITLE
Fix deprecation for TokenInterface::getRoles

### DIFF
--- a/src/UserContext/RoleProvider.php
+++ b/src/UserContext/RoleProvider.php
@@ -56,9 +56,13 @@ class RoleProvider implements ContextProvider
             return;
         }
 
-        $roles = array_map(function (Role $role) {
-            return $role->getRole();
-        }, $token->getRoles());
+        if (method_exists($token, 'getRoleNames')) {
+            $roles = $token->getRoleNames();
+        } else {
+            $roles = array_map(function (Role $role) {
+                return $role->getRole();
+            }, $token->getRoles());
+        }
 
         // Order is not important for roles and should not change hash.
         sort($roles);


### PR DESCRIPTION
Symfony deprecate the method `getRole` in favor of `getRoleNames`.

This PR update the RoleProvider to check the current behavior of symfony and use the best method.