### PR TITLE
Fix InvalidConfigurationException message after TagCapable support in logout_handler

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -143,7 +143,7 @@ class Configuration implements ConfigurationInterface
                         return $v;
                     }
 
-                    throw new InvalidConfigurationException('To enable the user context logout handler, you need to configure a tag capable proxy_client (varnish, symfony or noop).');
+                    throw new InvalidConfigurationException('To enable the user context logout handler, you need to configure a tag capable proxy_client (varnish, symfony, noop or custom_proxy_client).');
                 })
             ->end()
             // Determine the default tags header for the varnish client, depending on whether we use BAN or xkey

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -143,7 +143,7 @@ class Configuration implements ConfigurationInterface
                         return $v;
                     }
 
-                    throw new InvalidConfigurationException('To enable the user context logout handler, you need to configure a ban capable proxy_client.');
+                    throw new InvalidConfigurationException('To enable the user context logout handler, you need to configure a tag capable proxy_client (varnish, symfony or noop).');
                 })
             ->end()
             // Determine the default tags header for the varnish client, depending on whether we use BAN or xkey

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -608,9 +608,9 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
             'auto no client' => ['config/user_context_auto_noclient.yml', false, false, false, false, null],
             'auto ban client' => ['config/user_context_auto_banclient.yml', true, true, 'custom', 'auto', null],
             'auto non ban client' => ['config/user_context_auto_notbanclient.yml', false, 'auto', 'nginx', 'auto', null],
-            'true no client' => ['config/user_context_true_noclient.yml', null, false, 'auto', false, 'you need to configure a ban capable proxy_client'],
+            'true no client' => ['config/user_context_true_noclient.yml', null, false, 'auto', false, 'you need to configure a tag capable proxy_client'],
             'true ban client' => ['config/user_context_true_banclient.yml', true, true, 'custom', 'auto', null],
-            'true non ban client' => ['config/user_context_true_notbanclient.yml', null, true, 'nginx', 'auto', 'you need to configure a ban capable proxy_client'],
+            'true non ban client' => ['config/user_context_true_notbanclient.yml', null, true, 'nginx', 'auto', 'you need to configure a tag capable proxy_client'],
         ];
     }
 


### PR DESCRIPTION
Finishes #486
Fixes https://github.com/FriendsOfSymfony/FOSHttpCache/issues/456