### PR TITLE
bump symfony 3 version because security alert

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,9 +23,9 @@
     "require": {
         "php": "^7.2",
         "friendsofsymfony/http-cache": "^2.5.2",
-        "symfony/framework-bundle": "^3.4.4 || ^4.1.12 || ^5.0",
-        "symfony/http-foundation": "^3.4.4 || ^4.1.12 || ^5.0",
-        "symfony/http-kernel": "^3.4.4 || ^4.1.12 || ^5.0"
+        "symfony/framework-bundle": "^3.4.26 || ^4.1.12 || ^5.0",
+        "symfony/http-foundation": "^3.4.26 || ^4.1.12 || ^5.0",
+        "symfony/http-kernel": "^3.4.26 || ^4.1.12 || ^5.0"
     },
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0 || ^2.0",
@@ -34,16 +34,16 @@
         "monolog/monolog": "*",
         "sensio/framework-extra-bundle": "^3.0 || ^4.0 || ^5.0",
         "symfony/browser-kit": "^3.4.4 || ^4.1.12 || ^5.0",
-        "symfony/console": "^3.4.4 || ^4.1.12 || ^5.0",
-        "symfony/finder": "^3.4.4 || ^4.1.12 || ^5.0",
+        "symfony/console": "^3.4.26 || ^4.1.12 || ^5.0",
+        "symfony/finder": "^3.4.26 || ^4.1.12 || ^5.0",
         "symfony/phpunit-bridge": "^4.2.4 || ^5.0",
-        "symfony/security-bundle": "^3.4.4 || ^4.1.12 || ^5.0",
-        "symfony/twig-bundle": "^3.4.4 || ^4.1.12 || ^5.0",
-        "symfony/yaml": "^3.4.4 || ^4.1.12 || ^5.0",
-        "symfony/css-selector": "^3.4.4 || ^4.1.12 || ^5.0",
-        "symfony/expression-language": "^3.4.4 || ^4.1.12 || ^5.0",
+        "symfony/security-bundle": "^3.4.26 || ^4.1.12 || ^5.0",
+        "symfony/twig-bundle": "^3.4.26 || ^4.1.12 || ^5.0",
+        "symfony/yaml": "^3.4.26 || ^4.1.12 || ^5.0",
+        "symfony/css-selector": "^3.4.26 || ^4.1.12 || ^5.0",
+        "symfony/expression-language": "^3.4.26 || ^4.1.12 || ^5.0",
         "symfony/monolog-bundle": "^3.0 || ^4.1.12 || ^5.0",
-        "symfony/routing": "^3.4.4 || ^4.1.12 || ^5.0",
+        "symfony/routing": "^3.4.26 || ^4.1.12 || ^5.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
         "sebastian/exporter": "^2.0"
     },


### PR DESCRIPTION
symfony 3 seems also vulnerable and we should bump the minimum version there too: https://github.com/advisories/GHSA-g996-q5r8-w7g2