### PR TITLE
Add description on tags_header options when using xkey

### DIFF
--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -129,7 +129,7 @@ Header for sending tag invalidation requests to Varnish.
 
 For use with ``tag_mode: purgekeys``, default VCL supports two options:
 - ``xkey-softpurge``: "Soft purge" by tags, expires relevant cache and allows for grace handling.
-- ``xkey-purge``: Purge by tags, removes relevant cache and allows for grace handling.
+- ``xkey-purge``: Purge by tags, removes relevant cache immediately.
 
 See the :ref:`FOSHttpCache library docs <foshttpcache:varnish configuration>`
 on how to configure Varnish to handle tag invalidation requests.

--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -127,6 +127,10 @@ default ``xkey-softpurge``.
 
 Header for sending tag invalidation requests to Varnish.
 
+For use with ``tag_mode: purgekeys``, default VCL supports two options:
+- ``xkey-softpurge``: "Soft purge" by tags, expires relevant cache and allows for grace handling.
+- ``xkey-purge``: Purge by tags, removes relevant cache and allows for grace handling.
+
 See the :ref:`FOSHttpCache library docs <foshttpcache:varnish configuration>`
 on how to configure Varnish to handle tag invalidation requests.
 


### PR DESCRIPTION
xkey-purge option where only described in `tag_mode` section.