### PR TITLE
[Hash] Improve user hash change detection during request by comparing at the end

### DIFF
--- a/src/EventListener/UserContextListener.php
+++ b/src/EventListener/UserContextListener.php
@@ -78,9 +78,9 @@ class UserContextListener implements EventSubscriberInterface
     private $hasSessionListener;
 
     /**
-     * @var string
+     * @var bool
      */
-    private $hash;
+    private $wasAnonymous;
 
     /**
      * Used to exclude anonymous requests (no authentication nor session) from user hash sanity check.
@@ -138,12 +138,12 @@ class UserContextListener implements EventSubscriberInterface
 
         $request = $event->getRequest();
         if (!$this->requestMatcher->matches($request)) {
-            if ($event->getRequest()->headers->has($this->options['user_hash_header'])
-                && !$this->isAnonymous($event->getRequest())
-            ) {
-                $this->hash = $this->hashGenerator->generateHash();
+            if ($request->headers->has($this->options['user_hash_header'])) {
+                // Keep track of if user is anonymous when we have user hash header in request
+                $this->wasAnonymous = $this->isAnonymous($request);
             }
 
+            // Return early if request is not a hash lookup
             return;
         }
 
@@ -202,11 +202,18 @@ class UserContextListener implements EventSubscriberInterface
 
         $response = $event->getResponse();
         $request = $event->getRequest();
-
         $vary = $response->getVary();
 
         if ($request->headers->has($this->options['user_hash_header'])) {
-            if (null !== $this->hash && $this->hash !== $request->headers->get($this->options['user_hash_header'])) {
+            $requestHash = $request->headers->get($this->options['user_hash_header']);
+
+            // Generate hash to see if it might have changed during request if user was, or is "logged in" (session)
+            // But only needed if user was, or is, logged in
+            if (!$this->wasAnonymous || !$this->isAnonymous($request)) {
+                $hash = $this->hashGenerator->generateHash();
+            }
+
+            if (isset($hash) && $hash !== $requestHash) {
                 // hash has changed, session has most certainly changed, prevent setting incorrect cache
                 $response->setCache([
                     'max_age' => 0,

--- a/src/EventListener/UserContextListener.php
+++ b/src/EventListener/UserContextListener.php
@@ -181,8 +181,6 @@ class UserContextListener implements EventSubscriberInterface
      *
      * For backward compatibility reasons, true will be returned if no anonymous request matcher was provided.
      *
-     * @param Request $request
-     *
      * @return bool
      */
     private function isAnonymous(Request $request)

--- a/tests/Unit/EventListener/UserContextListenerTest.php
+++ b/tests/Unit/EventListener/UserContextListenerTest.php
@@ -61,7 +61,7 @@ class UserContextListenerTest extends TestCase
 
         $requestMatcher = $this->getRequestMatcher($request, true);
         $hashGenerator = \Mockery::mock(HashGenerator::class);
-        $hashGenerator->shouldReceive('generateHash')->andReturn('hash');
+        $hashGenerator->shouldReceive('generateHash')->once()->andReturn('hash');
         $responseTagger = \Mockery::mock(ResponseTagger::class);
         $responseTagger->shouldReceive('addTags')->with(['fos_http_cache_hashlookup-hash']);
 
@@ -123,7 +123,7 @@ class UserContextListenerTest extends TestCase
 
         $requestMatcher = $this->getRequestMatcher($request, true);
         $hashGenerator = \Mockery::mock(HashGenerator::class);
-        $hashGenerator->shouldReceive('generateHash')->andReturn('hash');
+        $hashGenerator->shouldReceive('generateHash')->once()->andReturn('hash');
         $responseTagger = \Mockery::mock(ResponseTagger::class);
         $responseTagger->shouldReceive('addTags')->with(['fos_http_cache_hashlookup-hash']);
 
@@ -158,7 +158,7 @@ class UserContextListenerTest extends TestCase
 
         $requestMatcher = $this->getRequestMatcher($request, false);
         $hashGenerator = \Mockery::mock(HashGenerator::class);
-        $hashGenerator->shouldReceive('generateHash')->andReturn('hash');
+        $hashGenerator->shouldReceive('generateHash')->never();
         $responseTagger = \Mockery::mock(ResponseTagger::class);
         $responseTagger->shouldReceive('addTags')->never();
 
@@ -166,6 +166,41 @@ class UserContextListenerTest extends TestCase
             $requestMatcher,
             $hashGenerator,
             null,
+            $responseTagger,
+            [
+                'user_identifier_headers' => ['X-SessionId'],
+                'user_hash_header' => 'X-Hash',
+            ]
+        );
+        $event = $this->getKernelRequestEvent($request);
+
+        $userContextListener->onKernelRequest($event);
+
+        $response = $event->getResponse();
+
+        $this->assertNull($response);
+    }
+
+    public function testOnKernelRequestNotMatchedHasHeader()
+    {
+        $request = new Request();
+        $request->setMethod('HEAD');
+        $request->headers->set('X-Hash', 'hash');
+
+        $requestMatcher = $this->getRequestMatcher($request, false);
+        $hashGenerator = \Mockery::mock(HashGenerator::class);
+        $hashGenerator->shouldReceive('generateHash')->never();
+        $responseTagger = \Mockery::mock(ResponseTagger::class);
+        $responseTagger->shouldReceive('addTags')->never();
+
+        // TODO anonymousRequestMatcher
+        $anonymousRequestMatcher = \Mockery::mock(RequestMatcherInterface::class);
+        $anonymousRequestMatcher->shouldReceive('matches')->once()->andReturn(true);
+
+        $userContextListener = new UserContextListener(
+            $requestMatcher,
+            $hashGenerator,
+            $anonymousRequestMatcher,
             $responseTagger,
             [
                 'user_identifier_headers' => ['X-SessionId'],
@@ -189,6 +224,7 @@ class UserContextListenerTest extends TestCase
 
         $requestMatcher = $this->getRequestMatcher($request, false);
         $hashGenerator = \Mockery::mock(HashGenerator::class);
+        $hashGenerator->shouldReceive('generateHash')->once()->andReturn('hash');
         $responseTagger = \Mockery::mock(ResponseTagger::class);
         $responseTagger->shouldReceive('addTags')->never();
 
@@ -221,6 +257,7 @@ class UserContextListenerTest extends TestCase
         $request->headers->set('X-User-Context-Hash', 'hash');
 
         $hashGenerator = \Mockery::mock(HashGenerator::class);
+        $hashGenerator->shouldReceive('generateHash')->once()->andReturn('hash');
 
         $userContextListener = new UserContextListener(
             $this->getRequestMatcher($request, false),
@@ -245,6 +282,7 @@ class UserContextListenerTest extends TestCase
         $request->headers->set('X-User-Context-Hash', 'hash');
 
         $hashGenerator = \Mockery::mock(HashGenerator::class);
+        $hashGenerator->shouldReceive('generateHash')->once()->andReturn('hash');
 
         $userContextListener = new UserContextListener(
             $this->getRequestMatcher($request, false),
@@ -273,6 +311,7 @@ class UserContextListenerTest extends TestCase
         $request->headers->set('X-User-Context-Hash', 'hash');
 
         $hashGenerator = \Mockery::mock(HashGenerator::class);
+        $hashGenerator->shouldReceive('generateHash')->once()->andReturn('hash');
 
         $userContextListener = new UserContextListener(
             $this->getRequestMatcher($request, false),
@@ -296,6 +335,7 @@ class UserContextListenerTest extends TestCase
         $request->headers->set('X-User-Context-Hash', 'hash');
 
         $hashGenerator = \Mockery::mock(HashGenerator::class);
+        $hashGenerator->shouldReceive('generateHash')->once()->andReturn('hash');
 
         $userContextListener = new UserContextListener(
             $this->getRequestMatcher($request, false),
@@ -324,6 +364,7 @@ class UserContextListenerTest extends TestCase
         $request->headers->set('X-User-Context-Hash', 'hash');
 
         $hashGenerator = \Mockery::mock(HashGenerator::class);
+        $hashGenerator->shouldReceive('generateHash')->once()->andReturn('hash');
 
         $userContextListener = new UserContextListener(
             $this->getRequestMatcher($request, false),
@@ -349,6 +390,7 @@ class UserContextListenerTest extends TestCase
 
         $requestMatcher = $this->getRequestMatcher($request, false);
         $hashGenerator = \Mockery::mock(HashGenerator::class);
+        $hashGenerator->shouldReceive('generateHash')->never();
 
         $userContextListener = new UserContextListener(
             $requestMatcher,
@@ -377,6 +419,7 @@ class UserContextListenerTest extends TestCase
 
         $requestMatcher = $this->getRequestMatcher($request, false);
         $hashGenerator = \Mockery::mock(HashGenerator::class);
+        $hashGenerator->shouldReceive('generateHash')->never();
 
         $userContextListener = new UserContextListener(
             $requestMatcher,
@@ -406,7 +449,7 @@ class UserContextListenerTest extends TestCase
 
         $requestMatcher = $this->getRequestMatcher($request, false);
         $hashGenerator = \Mockery::mock(HashGenerator::class);
-        $hashGenerator->shouldReceive('generateHash')->andReturn('hash');
+        $hashGenerator->shouldReceive('generateHash')->once()->andReturn('hash');
         $responseTagger = \Mockery::mock(ResponseTagger::class);
         $responseTagger->shouldReceive('addTags')->with(['fos_http_cache_usercontext-hash']);
 


### PR DESCRIPTION
Regarding discussion on user hash change detection, this is what I had in mind:
- Makes sure we generate hash to compare with on response => In case hash changed during current request
- Given we only generate hash if `! isAnonymous()` as a performance tweak => Still keep track of if user was logged in at request time, in case that changed in the meantime

TODO:
- [x] Adapt tests _(getting a "endTest() : void must be compatible with ..", so we might need to adjust something here due to new mockery / phpunit version)_