### PR TITLE
Fix CI Build and update PHPUnit

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -2,7 +2,6 @@ preset: symfony
 
 enabled:
   - alpha_ordered_imports
-  - short_array_syntax
 
 disabled:
   - single_line_throw

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ env:
   global:
         - PHPUNIT_FLAGS="-v"
         - SYMFONY_PHPUNIT_DIR="$HOME/symfony-bridge/.phpunit"
-        - SYMFONY_PHPUNIT_VERSION=6.5
 
 branches:
   only:

--- a/composer.json
+++ b/composer.json
@@ -36,7 +36,7 @@
         "symfony/browser-kit": "^3.4.4 || ^4.2.7 || ^5.0",
         "symfony/console": "^3.4.26 || ^4.2.7 || ^5.0",
         "symfony/finder": "^3.4.26 || ^4.2.7 || ^5.0",
-        "symfony/phpunit-bridge": "^4.2.4 || ^5.0",
+        "symfony/phpunit-bridge": "^4.4.11 || ^5.1.3",
         "symfony/security-bundle": "^3.4.26 || ^4.2.7 || ^5.0",
         "symfony/twig-bundle": "^3.4.26 || ^4.2.7 || ^5.0",
         "symfony/yaml": "^3.4.26 || ^4.2.7 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0 || ^2.0",
         "php-http/message": "^1.0 || ^2.0",
-        "mockery/mockery": "^1.0 || ^2.0",
+        "mockery/mockery": "^1.0",
         "monolog/monolog": "*",
         "sensio/framework-extra-bundle": "^3.0 || ^4.0 || ^5.0",
         "symfony/browser-kit": "^3.4.4 || ^4.2.7 || ^5.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
     "require-dev": {
         "php-http/guzzle6-adapter": "^1.0 || ^2.0",
         "php-http/message": "^1.0 || ^2.0",
-        "mockery/mockery": "^1.0",
+        "mockery/mockery": "^1.3.2",
         "monolog/monolog": "*",
         "sensio/framework-extra-bundle": "^3.0 || ^4.0 || ^5.0",
         "symfony/browser-kit": "^3.4.4 || ^4.2.7 || ^5.0",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,5 +32,6 @@
         <env name="KERNEL_DIR" value="./tests/Functional/Fixtures/app" />
         <env name="KERNEL_CLASS" value="AppKernel" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
     </php>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -4,8 +4,7 @@
          colors="true"
          convertErrorsToExceptions="true"
          convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         syntaxCheck="true">
+         convertWarningsToExceptions="true">
     <testsuites>
         <testsuite name="unit">
             <directory suffix="Test.php">./tests/Unit</directory>
@@ -32,6 +31,6 @@
         <env name="KERNEL_DIR" value="./tests/Functional/Fixtures/app" />
         <env name="KERNEL_CLASS" value="AppKernel" />
         <env name="SYMFONY_DEPRECATIONS_HELPER" value="weak" />
-        <server name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
+        <server name="SYMFONY_PHPUNIT_VERSION" value="8.5" />
     </php>
 </phpunit>

--- a/src/Security/Http/Logout/ContextInvalidationLogoutHandler.php
+++ b/src/Security/Http/Logout/ContextInvalidationLogoutHandler.php
@@ -41,9 +41,9 @@ final class ContextInvalidationLogoutHandler implements LogoutHandlerInterface
         @trigger_error('Using the ContextInvalidationLogoutHandler is deprecated', E_USER_DEPRECATED);
 
         if (class_exists(LogoutEvent::class)) {
-            // This function should not longer be called in Symfony 5.1
+            // This class no longer works at all with Symfony 5.1, force usage of ContextInvalidationSessionLogoutHandler instead
             // See also: https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/545#discussion_r465089219
-            throw new \LogicException(__CLASS__.'::'.__METHOD__.' is deprecated and should since Symfony 5.1 not longer be called.');
+            throw new \LogicException(__CLASS__.'::'.__METHOD__.' no longer works with Symfony 5.1. Remove fos_http_cache.user_context.logout_handler from your firewall configuration. See the changelog for version 2.2. for more information.');
         }
 
         $this->invalidator->invalidateContext($request->getSession()->getId());

--- a/src/Security/Http/Logout/ContextInvalidationLogoutHandler.php
+++ b/src/Security/Http/Logout/ContextInvalidationLogoutHandler.php
@@ -15,6 +15,7 @@ use FOS\HttpCacheBundle\UserContextInvalidator;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
 use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
 
 /**
@@ -38,6 +39,13 @@ final class ContextInvalidationLogoutHandler implements LogoutHandlerInterface
     public function logout(Request $request, Response $response, TokenInterface $token)
     {
         @trigger_error('Using the ContextInvalidationLogoutHandler is deprecated', E_USER_DEPRECATED);
+
+        if (class_exists(LogoutEvent::class)) {
+            // This function should not longer be called in Symfony 5.1
+            // See also: https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/545#discussion_r465089219
+            throw new \LogicException(__CLASS__.'::'.__METHOD__.' is deprecated and should since Symfony 5.1 not longer be called.');
+        }
+
         $this->invalidator->invalidateContext($request->getSession()->getId());
     }
 }

--- a/tests/Functional/DependencyInjection/ServiceTest.php
+++ b/tests/Functional/DependencyInjection/ServiceTest.php
@@ -58,7 +58,7 @@ class ServiceTest extends KernelTestCase
             if ('fos_http_cache.user_context.logout_handler' === $id) {
                 continue;
             }
-            $this->assertInternalType('object', $container->get($id));
+            $this->assertIsObject($container->get($id));
         }
     }
 }

--- a/tests/Functional/EventListener/CacheControlListenerTest.php
+++ b/tests/Functional/EventListener/CacheControlListenerTest.php
@@ -34,6 +34,6 @@ class CacheControlListenerTest extends WebTestCase
         $client->request('GET', '/noncached');
         $response = $client->getResponse();
         // using contains because Symfony 3.2 add `private` when the cache is not public
-        $this->assertContains('no-cache', $response->headers->get('Cache-Control'));
+        $this->assertStringContainsString('no-cache', $response->headers->get('Cache-Control'));
     }
 }

--- a/tests/Functional/Security/Http/Logout/ContextInvalidationLogoutHandlerTest.php
+++ b/tests/Functional/Security/Http/Logout/ContextInvalidationLogoutHandlerTest.php
@@ -26,6 +26,7 @@ class ContextInvalidationLogoutHandlerTest extends WebTestCase
     {
         if (class_exists(LogoutEvent::class)) {
             // @see https://github.com/symfony/symfony/pull/36243/files#r465083756
+            // @see https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/pull/545/files#diff-05cbcfd492fd361b33ee70130dc687b2
             $this->markTestSkipped('This test does not work with Symfony 5.1.');
         }
 

--- a/tests/Functional/Security/Http/Logout/ContextInvalidationLogoutHandlerTest.php
+++ b/tests/Functional/Security/Http/Logout/ContextInvalidationLogoutHandlerTest.php
@@ -16,6 +16,7 @@ use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 use Symfony\Component\BrowserKit\Cookie;
 use Symfony\Component\Security\Core\Authentication\Token\UsernamePasswordToken;
+use Symfony\Component\Security\Http\Event\LogoutEvent;
 
 class ContextInvalidationLogoutHandlerTest extends WebTestCase
 {
@@ -23,6 +24,11 @@ class ContextInvalidationLogoutHandlerTest extends WebTestCase
 
     public function testLogout()
     {
+        if (class_exists(LogoutEvent::class)) {
+            // @see https://github.com/symfony/symfony/pull/36243/files#r465083756
+            $this->markTestSkipped('This test does not work with Symfony 5.1.');
+        }
+
         $client = static::createClient();
         $session = $client->getContainer()->get('session');
 

--- a/tests/Unit/CacheManagerTest.php
+++ b/tests/Unit/CacheManagerTest.php
@@ -25,7 +25,7 @@ class CacheManagerTest extends TestCase
 
     protected $proxyClient;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->proxyClient = \Mockery::mock(ProxyClient::class);
     }

--- a/tests/Unit/Command/InvalidatePathCommandTest.php
+++ b/tests/Unit/Command/InvalidatePathCommandTest.php
@@ -22,11 +22,10 @@ class InvalidatePathCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testExecuteMissingParameters()
     {
+        $this->expectException(\RuntimeException::class);
+
         $invalidator = \Mockery::mock(CacheManager::class);
 
         $application = new Application();

--- a/tests/Unit/Command/InvalidateRegexCommandTest.php
+++ b/tests/Unit/Command/InvalidateRegexCommandTest.php
@@ -22,11 +22,10 @@ class InvalidateRegexCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testExecuteNoParameters()
     {
+        $this->expectException(\RuntimeException::class);
+
         $invalidator = \Mockery::mock(CacheManager::class);
 
         $application = new Application();

--- a/tests/Unit/Command/InvalidateTagCommandTest.php
+++ b/tests/Unit/Command/InvalidateTagCommandTest.php
@@ -22,11 +22,10 @@ class InvalidateTagCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testExecuteMissingParameters()
     {
+        $this->expectException(\RuntimeException::class);
+
         $invalidator = \Mockery::mock(CacheManager::class);
 
         $application = new Application();

--- a/tests/Unit/Command/RefreshPathCommandTest.php
+++ b/tests/Unit/Command/RefreshPathCommandTest.php
@@ -22,11 +22,10 @@ class RefreshPathCommandTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testExecuteMissingParameters()
     {
+        $this->expectException(\RuntimeException::class);
+
         $invalidator = \Mockery::mock(CacheManager::class);
 
         $application = new Application();

--- a/tests/Unit/Configuration/InvalidateRouteTest.php
+++ b/tests/Unit/Configuration/InvalidateRouteTest.php
@@ -22,24 +22,22 @@ class InvalidateRouteTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage InvalidateRoute params must be an array
-     */
     public function testExecuteInvalidParams()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('InvalidateRoute params must be an array');
+
         new InvalidateRoute([
             'name' => 'test',
             'params' => 'foo',
         ]);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage InvalidateRoute param id must be string
-     */
     public function testExecuteNoExpression()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('InvalidateRoute param id must be string');
+
         new InvalidateRoute([
             'name' => 'test',
             'params' => [

--- a/tests/Unit/Configuration/TagTest.php
+++ b/tests/Unit/Configuration/TagTest.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCacheBundle\Tests\Unit\Configuration;
 
 use FOS\HttpCacheBundle\Configuration\Tag;
+use FOS\HttpCacheBundle\Exception\InvalidTagException;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 
@@ -22,12 +23,11 @@ class TagTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @expectedException \FOS\HttpCacheBundle\Exception\InvalidTagException
-     * @expectedExceptionMessage is invalid because it contains ,
-     */
     public function testExecuteInvalidParams()
     {
+        $this->expectException(InvalidTagException::class);
+        $this->expectExceptionMessage('is invalid because it contains ,');
+
         new Tag([
             'tags' => ['foo, bar'],
         ]);

--- a/tests/Unit/DependencyInjection/Compiler/HashGeneratorPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/HashGeneratorPassTest.php
@@ -15,6 +15,7 @@ use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\ParameterBag\ParameterBag;
@@ -33,7 +34,7 @@ class HashGeneratorPassTest extends TestCase
      */
     private $userContextListenerPass;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->extension = new FOSHttpCacheExtension();
         $this->userContextListenerPass = new HashGeneratorPass();
@@ -56,12 +57,11 @@ class HashGeneratorPassTest extends TestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage No user context providers found
-     */
     public function testConfigNoProviders()
     {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('No user context providers found');
+
         $container = $this->createContainer();
         $config = $this->getBaseConfig();
         $config['user_context']['enabled'] = true;

--- a/tests/Unit/DependencyInjection/Compiler/TagListenerPassTest.php
+++ b/tests/Unit/DependencyInjection/Compiler/TagListenerPassTest.php
@@ -22,12 +22,11 @@ class TagListenerPassTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage require the SensioFrameworkExtraBundle
-     */
     public function testNoFrameworkBundle()
     {
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('require the SensioFrameworkExtraBundle');
+
         $extension = new FOSHttpCacheExtension();
         $tagListenerPass = new TagListenerPass();
         $container = $this->createContainer();

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -298,12 +298,11 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         }
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage Either configure the "http.servers" section or enable "proxy_client.symfony.use_kernel_dispatcher
-     */
     public function testEmptyServerConfigurationIsNotAllowed()
     {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('Either configure the "http.servers" section or enable "proxy_client.symfony.use_kernel_dispatcher');
+
         $params = $this->getEmptyConfig();
         $params['proxy_client'] = [
             'symfony' => [
@@ -457,7 +456,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 $this->assertProcessedConfigurationEquals([], [$format]);
                 $this->fail('No exception thrown on invalid configuration');
             } catch (InvalidConfigurationException $e) {
-                $this->assertContains('need to configure a proxy_client', $e->getMessage());
+                $this->assertStringContainsString('need to configure a proxy_client', $e->getMessage());
             }
         }
     }
@@ -477,7 +476,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 $this->assertProcessedConfigurationEquals([], [$format]);
                 $this->fail('No exception thrown on invalid configuration');
             } catch (InvalidConfigurationException $e) {
-                $this->assertContains('cache_manager needed for tag handling', $e->getMessage());
+                $this->assertStringContainsString('cache_manager needed for tag handling', $e->getMessage());
             }
         }
     }
@@ -599,7 +598,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 $this->assertProcessedConfigurationEquals([], [$format]);
                 $this->fail('No exception thrown on invalid configuration');
             } catch (InvalidConfigurationException $e) {
-                $this->assertContains('cache_manager needed for invalidation handling', $e->getMessage());
+                $this->assertStringContainsString('cache_manager needed for invalidation handling', $e->getMessage());
             }
         }
     }
@@ -627,7 +626,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 $this->assertProcessedConfigurationEquals([], [$configFile]);
                 $this->fail('No exception thrown on invalid configuration');
             } catch (InvalidConfigurationException $e) {
-                $this->assertContains($exception, $e->getMessage());
+                $this->assertStringContainsString($exception, $e->getMessage());
             }
 
             return;
@@ -667,7 +666,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 $this->assertProcessedConfigurationEquals([], [$format]);
                 $this->fail('No exception thrown on invalid configuration');
             } catch (InvalidConfigurationException $e) {
-                $this->assertContains('Failed to parse time string', $e->getMessage());
+                $this->assertStringContainsString('Failed to parse time string', $e->getMessage());
             }
         }
     }

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -34,7 +34,7 @@ class FOSHttpCacheExtensionTest extends TestCase
      */
     protected $extension;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->extension = new FOSHttpCacheExtension();
     }
@@ -65,11 +65,10 @@ class FOSHttpCacheExtensionTest extends TestCase
         $this->assertEquals('my_guzzle', $def->getArgument(2)->__toString());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testConfigLoadVarnishInvalidUrl()
     {
+        $this->expectException(InvalidConfigurationException::class);
+
         $container = $this->createContainer();
         $config = $this->getBaseConfig();
         $config['proxy_client']['varnish']['http']['base_url'] = 'ftp:not a valid url';
@@ -193,12 +192,11 @@ class FOSHttpCacheExtensionTest extends TestCase
         $this->assertFalse($container->has('fos_http_cache.user_context.logout_handler'));
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     * @expectedExceptionMessage You can not enable cache tagging with the nginx client
-     */
     public function testConfigTagNotSupported()
     {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You can not enable cache tagging with the nginx client');
+
         $config = [
                 'proxy_client' => [
                     'nginx' => [

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -693,9 +693,7 @@ class FOSHttpCacheExtensionTest extends TestCase
     }
 
     /**
-     * @param ContainerBuilder $container
-     * @param array            $attributes
-     * @param array            $methods    List of methods for the matcher. Empty array to not check.
+     * @param array $methods List of methods for the matcher. Empty array to not check.
      *
      * @return string Service id of the matcher
      */
@@ -730,8 +728,7 @@ class FOSHttpCacheExtensionTest extends TestCase
     }
 
     /**
-     * @param ContainerBuilder $container
-     * @param int[]            $additionalStatus
+     * @param int[] $additionalStatus
      *
      * @return DefinitionDecorator|ChildDefinition
      */
@@ -760,8 +757,7 @@ class FOSHttpCacheExtensionTest extends TestCase
     }
 
     /**
-     * @param ContainerBuilder $container
-     * @param string           $expression
+     * @param string $expression
      *
      * @return DefinitionDecorator|ChildDefinition
      */
@@ -792,8 +788,7 @@ class FOSHttpCacheExtensionTest extends TestCase
     /**
      * Assert that the service $id exists and has a method call mapped onto it.
      *
-     * @param ContainerBuilder $container
-     * @param string           $id        The service id to investigate
+     * @param string $id The service id to investigate
      */
     private function assertListenerHasRule(ContainerBuilder $container, $id)
     {

--- a/tests/Unit/EventListener/CacheControlListenerTest.php
+++ b/tests/Unit/EventListener/CacheControlListenerTest.php
@@ -270,7 +270,7 @@ class CacheControlListenerTest extends TestCase
         $listener->onKernelResponse($event);
         $newHeaders = $event->getResponse()->headers->all();
 
-        $this->assertContains('no-cache', $newHeaders['cache-control'][0]);
+        $this->assertStringContainsString('no-cache', $newHeaders['cache-control'][0]);
     }
 
     public function testSetOnlyNoStoreHeader()
@@ -287,7 +287,7 @@ class CacheControlListenerTest extends TestCase
         $listener->onKernelResponse($event);
         $newHeaders = $event->getResponse()->headers->all();
 
-        $this->assertContains('no-store', $newHeaders['cache-control'][0]);
+        $this->assertStringContainsString('no-store', $newHeaders['cache-control'][0]);
     }
 
     public function testSkip()
@@ -303,7 +303,7 @@ class CacheControlListenerTest extends TestCase
         $listener->onKernelResponse($event);
         $newHeaders = $event->getResponse()->headers->all();
 
-        $this->assertContains('no-cache', $newHeaders['cache-control'][0]);
+        $this->assertStringContainsString('no-cache', $newHeaders['cache-control'][0]);
     }
 
     public function testVary()
@@ -394,7 +394,7 @@ class CacheControlListenerTest extends TestCase
 
         $listener->onKernelResponse($event2);
         $newHeaders = $response2->headers->all();
-        $this->assertContains('no-cache', $newHeaders['cache-control'][0]);
+        $this->assertStringContainsString('no-cache', $newHeaders['cache-control'][0]);
     }
 
     /**

--- a/tests/Unit/EventListener/CacheControlListenerTest.php
+++ b/tests/Unit/EventListener/CacheControlListenerTest.php
@@ -402,14 +402,12 @@ class CacheControlListenerTest extends TestCase
      */
     public function testUnsafeMethod()
     {
-        /** @var CacheControlListener|\PHPUnit_Framework_MockObject_MockObject $listener */
-        $listener = $this->getMockBuilder(CacheControlListener::class)
-            ->setMethods(['matchRule'])
-            ->getMock()
-        ;
-        $listener->expects($this->never())
-            ->method('matchRule')
-        ;
+        $listener = new CacheControlListener();
+        $matcher = \Mockery::mock(RuleMatcherInterface::class)
+            ->shouldReceive('matches')->never()
+            ->getMock();
+        $listener->addRule($matcher);
+
         $event = $this->buildEvent('POST');
 
         $listener->onKernelResponse($event);

--- a/tests/Unit/EventListener/InvalidationListenerTest.php
+++ b/tests/Unit/EventListener/InvalidationListenerTest.php
@@ -62,7 +62,7 @@ class InvalidationListenerTest extends TestCase
      */
     private $listener;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cacheManager = \Mockery::mock(CacheManager::class);
         $this->urlGenerator = \Mockery::mock(UrlGeneratorInterface::class);

--- a/tests/Unit/EventListener/TagListenerTest.php
+++ b/tests/Unit/EventListener/TagListenerTest.php
@@ -61,7 +61,7 @@ class TagListenerTest extends TestCase
      */
     private $cacheableRule;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->cacheManager = \Mockery::mock(
             CacheManager::class

--- a/tests/Unit/EventListener/UserContextListenerTest.php
+++ b/tests/Unit/EventListener/UserContextListenerTest.php
@@ -542,8 +542,7 @@ class UserContextListenerTest extends TestCase
     }
 
     /**
-     * @param Request $request
-     * @param bool    $match
+     * @param bool $match
      *
      * @return \Mockery\MockInterface|RequestMatcherInterface
      */

--- a/tests/Unit/EventListener/UserContextListenerTest.php
+++ b/tests/Unit/EventListener/UserContextListenerTest.php
@@ -39,11 +39,10 @@ class UserContextListenerTest extends TestCase
 {
     use MockeryPHPUnitIntegration;
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testMisconfiguration()
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         new UserContextListener(
             \Mockery::mock(RequestMatcherInterface::class),
             \Mockery::mock(HashGenerator::class),
@@ -208,7 +207,7 @@ class UserContextListenerTest extends TestCase
         $userContextListener->onKernelResponse($event);
 
         $this->assertTrue($event->getResponse()->headers->has('Vary'), 'Vary header must be set');
-        $this->assertContains('X-Hash', $event->getResponse()->headers->get('Vary'));
+        $this->assertStringContainsString('X-Hash', $event->getResponse()->headers->get('Vary'));
     }
 
     public function testOnKernelResponseSetsNoAutoCacheHeader()
@@ -231,7 +230,7 @@ class UserContextListenerTest extends TestCase
 
         $userContextListener->onKernelResponse($event);
 
-        $this->assertContains('X-User-Context-Hash', $event->getResponse()->headers->get('Vary'));
+        $this->assertStringContainsString('X-User-Context-Hash', $event->getResponse()->headers->get('Vary'));
         $this->assertEquals(1, $event->getResponse()->headers->get(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
     }
 
@@ -259,7 +258,7 @@ class UserContextListenerTest extends TestCase
 
         $userContextListener->onKernelResponse($event);
 
-        $this->assertContains('X-User-Context-Hash', $event->getResponse()->headers->get('Vary'));
+        $this->assertStringContainsString('X-User-Context-Hash', $event->getResponse()->headers->get('Vary'));
         $this->assertFalse($event->getResponse()->headers->has(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER));
     }
 
@@ -434,7 +433,7 @@ class UserContextListenerTest extends TestCase
         $event = $this->getKernelResponseEvent($request);
         $userContextListener->onKernelResponse($event);
 
-        $this->assertContains('X-Hash', $event->getResponse()->headers->get('Vary'));
+        $this->assertStringContainsString('X-Hash', $event->getResponse()->headers->get('Vary'));
     }
 
     /**
@@ -478,7 +477,7 @@ class UserContextListenerTest extends TestCase
         $event = $this->getKernelResponseEvent($request);
         $userContextListener->onKernelResponse($event);
 
-        $this->assertContains('X-Hash', $event->getResponse()->headers->get('Vary'));
+        $this->assertStringContainsString('X-Hash', $event->getResponse()->headers->get('Vary'));
     }
 
     /**

--- a/tests/Unit/UserContext/RoleProviderTest.php
+++ b/tests/Unit/UserContext/RoleProviderTest.php
@@ -15,6 +15,7 @@ use FOS\HttpCache\UserContext\UserContext;
 use FOS\HttpCacheBundle\UserContext\RoleProvider;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Security\Core\Authentication\Token\AnonymousToken;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
@@ -62,11 +63,10 @@ class RoleProviderTest extends TestCase
         $this->assertEmpty($userContext->getParameters());
     }
 
-    /**
-     * @expectedException \Symfony\Component\Config\Definition\Exception\InvalidConfigurationException
-     */
     public function testNotUnderFirewall()
     {
+        $this->expectException(InvalidConfigurationException::class);
+
         $roleProvider = new RoleProvider();
         $roleProvider->updateUserContext(new UserContext());
     }


### PR DESCRIPTION
Locally I run into the following problem:

> PHP Fatal error:  Declaration of FOS\HttpCacheBundle\Tests\Unit\CacheManagerTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in ~/Sulu/sulu-develop.localhost/vendor/friendsofsymfony/http-cache-bundle/tests/Unit/CacheManagerTest.php on line 28

> Fatal error: Declaration of FOS\HttpCacheBundle\Tests\Unit\CacheManagerTest::setUp() must be compatible with PHPUnit\Framework\TestCase::setUp(): void in ~/Sulu/sulu-develop.localhost/vendor/friendsofsymfony/http-cache-bundle/tests/Unit/CacheManagerTest.php on line 28

This seems to be fixed by using:

```xml
<server name="SYMFONY_PHPUNIT_VERSION" value="6.5" />
```

Which seems to be set in the [.travis.yml](https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/396eea2c79661fe591a80788de4d7ae671c76b49/.travis.yml#L20) also. I think I would remove it there so it works locally also.

But then I run into the following error:

> PHP Fatal error:  Declaration of Mockery\Adapter\Phpunit\TestListener::endTest(PHPUnit\Framework\Test $test, float $time): void must be compatible with PHPUnit\Framework\TestListener::endTest(PHPUnit\Framework\Test $test, $time) in /Users/alexanderschranz/Documents/Sulu/sulu20-develop.localhost/vendor/friendsofsymfony/http-cache-bundle/vendor/mockery/mockery/library/Mockery/Adapter/Phpunit/TestListener.php on line 39

So I decided to update to PHPUnit 8. Which seems to fix this error.