### PR TITLE
[Bug] Flash messages are overwritten with redirects

### DIFF
--- a/src/EventListener/FlashMessageListener.php
+++ b/src/EventListener/FlashMessageListener.php
@@ -88,14 +88,20 @@ final class FlashMessageListener implements EventSubscriberInterface
             return;
         }
 
+        $response = $event->getResponse();
+
+        // If the response is a redirect, we should wait until the final response
+        // is reached
+        if ($response->isRedirect()) {
+            return;
+        }
+
         $flashBag = $this->session->getFlashBag();
         $flashes = $flashBag->all();
 
         if (empty($flashes)) {
             return;
         }
-
-        $response = $event->getResponse();
 
         $cookies = $response->headers->getCookies(ResponseHeaderBag::COOKIES_ARRAY);
         $host = (null === $this->options['host']) ? '' : $this->options['host'];

--- a/tests/Functional/Fixtures/Controller/FlashMessageController.php
+++ b/tests/Functional/Fixtures/Controller/FlashMessageController.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Response;
 
 if (!\class_exists(AbstractController::class)) {
@@ -29,5 +30,15 @@ class FlashMessageController extends AbstractController
         );
 
         return new Response('flash');
+    }
+
+    public function flashRedirectAction()
+    {
+        $this->addFlash(
+            'notice',
+            'Flash Message!'
+        );
+
+        return new RedirectResponse('/flash');
     }
 }

--- a/tests/Functional/Fixtures/app/config/routing.yml
+++ b/tests/Functional/Fixtures/app/config/routing.yml
@@ -56,5 +56,9 @@ test_flash:
   path: /flash
   defaults: { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\FlashMessageController::flashAction }
 
+test_flash_redirect:
+  path: /flash-redirect
+  defaults: { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\FlashMessageController::flashRedirectAction }
+
 user_context_hash:
     path: /secured_area/_fos_user_context_hash

--- a/tests/Functional/Fixtures/app/config/routing_41.yml
+++ b/tests/Functional/Fixtures/app/config/routing_41.yml
@@ -56,5 +56,9 @@ test_flash:
   path: /flash
   controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\FlashMessageController::flashAction
 
+test_flash_redirect:
+  path: /flash-redirect
+  defaults: { _controller: FOS\HttpCacheBundle\Tests\Functional\Fixtures\Controller\FlashMessageController::flashRedirectAction }
+
 user_context_hash:
     path: /secured_area/_fos_user_context_hash


### PR DESCRIPTION
## How to reproduce
1. Add a flash message on a controller
2. Return a `RedirectResponse` from that controller to another one
3. Add another flash message on the second controller

## What is expected
The `flashes` cookie should contain both messages

## What happens
When the second controller adds the flash message, the `FlashMessageListener` tries to get the cookie from the response header and can't find it, thus doesn't merge the old message with the new one in the newly formed cookie.

## Solution
Check if the request is a redirect and only set the cookie to the last response