### PR TITLE
feat: support env var in varnish config for servers key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+2.11.0
+------
+
+### Added
+
+* New configuration option `servers_from_jsonenv` to support a variable amount of proxy servers defined via an environment variable.
+
 2.10.3
 ------
 

--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -37,8 +37,9 @@ varnish
                     servers:
                         - 123.123.123.1:6060
                         - 123.123.123.2
+                    # alternatively, if you configure the varnish servers in an environment variable:
+                    # servers_from_jsonenv: '%env(json:VARNISH_SERVERS)%'
                     base_url: yourwebsite.com
-                    servers_from_jsonenv: '%env(json:VARNISH_SERVERS)%'
 
 ``header_length``
 """""""""""""""""
@@ -70,8 +71,10 @@ When using a multi-server setup, make sure to include **all** proxy servers in
 this list. Invalidation must happen on all systems or you will end up with
 inconsistent caches.
 
-Note: when using a variable amount of proxy servers that are defined via environment
-variable, use the ``http.servers_from_jsonenv`` option below.
+.. note::
+
+    When using a variable amount of proxy servers that are defined via environment
+    variable, use the ``http.servers_from_jsonenv`` option below.
 
 ``http.servers_from_jsonenv``
 """""""""""""""""""""""""""""

--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -38,6 +38,7 @@ varnish
                         - 123.123.123.1:6060
                         - 123.123.123.2
                     base_url: yourwebsite.com
+                    servers_from_jsonenv: '%env(json:VARNISH_SERVERS)%'
 
 ``header_length``
 """""""""""""""""
@@ -68,6 +69,24 @@ defaults to 80; you can specify a different port with ``:<port>``.
 When using a multi-server setup, make sure to include **all** proxy servers in
 this list. Invalidation must happen on all systems or you will end up with
 inconsistent caches.
+
+Note: when using a variable amount of proxy servers that are defined via environment
+variable, use the ``http.servers_from_jsonenv`` option below.
+
+``http.servers_from_jsonenv``
+"""""""""""""""""""""""""""""
+
+**type**: ``string``
+
+Json encoded servers array as string. The servers array has the same specs as ``http.servers``.
+
+Use this option only when using a variable amount of proxy servers that shall be defined via
+environment variable. Otherwise use the regular ``http.servers`` option.
+
+Usage:
+* fos_http_cache.yaml: ``servers_from_jsonenv: '%env(json:VARNISH_SERVERS)%'``
+* environment definition: ``VARNISH_SERVERS='["123.123.123.1:6060","123.123.123.2"]'``
+
 
 ``http.base_url``
 """""""""""""""""

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -365,12 +365,23 @@ class FOSHttpCacheExtension extends Extension
      */
     private function createHttpDispatcherDefinition(ContainerBuilder $container, array $config, $serviceName)
     {
-        foreach ($config['servers'] as $url) {
-            $usedEnvs = [];
-            $container->resolveEnvPlaceholders($url, null, $usedEnvs);
-            if (0 === \count($usedEnvs)) {
-                $this->validateUrl($url, 'Not a valid Varnish server address: "%s"');
+        if (array_key_exists('servers', $config)) {
+            foreach ($config['servers'] as $url) {
+                $usedEnvs = [];
+                $container->resolveEnvPlaceholders($url, null, $usedEnvs);
+                if (0 === \count($usedEnvs)) {
+                    $this->validateUrl($url, 'Not a valid Varnish server address: "%s"');
+                }
             }
+        }
+        if (array_key_exists('servers_from_jsonenv', $config) && is_string($config['servers_from_jsonenv'])) {
+            // check that the config contains an env var
+            $usedEnvs = [];
+            $container->resolveEnvPlaceholders($config['servers_from_jsonenv'], null, $usedEnvs);
+            if (0 === \count($usedEnvs)) {
+                throw new InvalidConfigurationException('Not a valid Varnish servers_from_jsonenv configuration: '.$config['servers_from_jsonenv']);
+            }
+            $config['servers'] = $config['servers_from_jsonenv'];
         }
         if (!empty($config['base_url'])) {
             $baseUrl = $config['base_url'];

--- a/tests/Resources/Fixtures/config/servers_from_jsonenv.php
+++ b/tests/Resources/Fixtures/config/servers_from_jsonenv.php
@@ -1,0 +1,22 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCacheBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$container->loadFromExtension('fos_http_cache', [
+    'proxy_client' => [
+        'varnish' => [
+            'http' => [
+                'servers_from_jsonenv' => '%env(json:VARNISH_SERVERS)%',
+                'base_url' => '/test',
+                'http_client' => 'acme.guzzle.nginx',
+            ],
+        ],
+    ],
+]);

--- a/tests/Resources/Fixtures/config/servers_from_jsonenv.xml
+++ b/tests/Resources/Fixtures/config/servers_from_jsonenv.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services">
+
+    <config xmlns="http://example.org/schema/dic/fos_http_cache">
+        <proxy-client>
+            <varnish>
+                <http base-url="/test" http-client="acme.guzzle.nginx" servers-from-jsonenv="%env(json:VARNISH_SERVERS)%" />
+            </varnish>
+        </proxy-client>
+
+    </config>
+</container>

--- a/tests/Resources/Fixtures/config/servers_from_jsonenv.yml
+++ b/tests/Resources/Fixtures/config/servers_from_jsonenv.yml
@@ -1,0 +1,8 @@
+fos_http_cache:
+
+  proxy_client:
+    varnish:
+      http:
+        servers_from_jsonenv: '%env(json:VARNISH_SERVERS)%'
+        base_url: /test
+        http_client: acme.guzzle.nginx


### PR DESCRIPTION
I tried to solve #521 with this pull request:

in addition to the regular case (array of servers) the configuration for `varnish.servers` can now be a string holding an environment variable. The environment variable is supposed to be a string that contains a json array of servers.

This solves the problem, that the same app under different environments might have different server configurations. Eg some test setup might have one varnish and a production setup might have three varnish.

To solve the issue, I had to loosen the checks in `Configuration.php` a bit.