### PR TITLE
Fix servers from env vars

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -547,7 +547,7 @@ class Configuration implements ConfigurationInterface
                     ->requiresAtLeastOneElement()
                     ->prototype('scalar')->end()
                 ->end()
-                ->scalarNode('servers_from_jsonenv')
+                ->variableNode('servers_from_jsonenv')
                     ->info('Addresses of the hosts the caching proxy is running on (env var that contains a json array as a string). The values may be hostnames or ips, and with :port if not the default port 80.')
                 ->end()
                 ->scalarNode('base_url')

--- a/tests/Functional/DependencyInjection/ServersFromEnvTest.php
+++ b/tests/Functional/DependencyInjection/ServersFromEnvTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Tests\Functional\DependencyInjection;
+
+use FOS\HttpCache\ProxyClient\HttpDispatcher;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\DependencyInjection\Container;
+use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+class ServersFromEnvTest extends KernelTestCase
+{
+    /**
+     * Boots a special kernel with a compiler pass to make all services public for this test.
+     *
+     * @return KernelInterface A KernelInterface instance
+     */
+    protected function bootDebugKernel()
+    {
+        static::ensureKernelShutdown();
+        static::$kernel = static::createKernel();
+        assert(static::$kernel instanceof \AppKernel);
+        static::$kernel->addCompilerPass(new ServicesPublicPass());
+        $fs = new Filesystem();
+        $fs->remove(static::$kernel->getCacheDir());
+        static::$kernel->boot();
+
+        return static::$kernel;
+    }
+
+    public function testServersFromEnv()
+    {
+        // define the kernel config to use for this test
+        $_ENV['KERNEL_CONFIG'] = 'config_servers_from_env.yml';
+
+        // test env var as json string, that will get deserialized and injected into http dispatcher
+        $_ENV['VARNISH_SERVERS'] = '["localhost:123","https://any.host:456"]';
+
+        /** @var Container $container */
+        $container = $this->bootDebugKernel()->getContainer();
+
+        /** @var HttpDispatcher $fosHttpCache */
+        $fosHttpCache = $container->get('fos_http_cache.proxy_client.varnish.http_dispatcher');
+
+        $reflectionObject = new \ReflectionClass($fosHttpCache);
+        $reflectionGetServers = $reflectionObject->getMethod('getServers');
+        $reflectionGetServers->setAccessible(true);
+        $uris = $reflectionGetServers->invoke($fosHttpCache);
+        $servers = array_map(function ($uri) { return $uri->__toString(); }, $uris);
+
+        static::assertEquals(['http://localhost:123', 'https://any.host:456'], $servers);
+
+        // unset env vars, so next tests do not fail (KERNEL_CONFIG)
+        unset($_ENV['KERNEL_CONFIG'], $_ENV['VARNISH_SERVERS']);
+    }
+}

--- a/tests/Functional/DependencyInjection/ServiceTest.php
+++ b/tests/Functional/DependencyInjection/ServiceTest.php
@@ -12,9 +12,7 @@
 namespace FOS\HttpCacheBundle\Tests\Functional\DependencyInjection;
 
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\Container;
-use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\HttpKernel\KernelInterface;
 
@@ -59,23 +57,6 @@ class ServiceTest extends KernelTestCase
                 continue;
             }
             $this->assertIsObject($container->get($id));
-        }
-    }
-}
-
-class ServicesPublicPass implements CompilerPassInterface
-{
-    public function process(ContainerBuilder $container)
-    {
-        foreach ($container->getServiceIds() as $id) {
-            if (strncmp('fos_http_cache.', $id, 15)) {
-                continue;
-            }
-            if ($container->hasDefinition($id)) {
-                $container->getDefinition($id)->setPublic(true);
-            } elseif ($container->hasAlias($id)) {
-                $container->getAlias($id)->setPublic(true);
-            }
         }
     }
 }

--- a/tests/Functional/DependencyInjection/ServicesPublicPass.php
+++ b/tests/Functional/DependencyInjection/ServicesPublicPass.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace FOS\HttpCacheBundle\Tests\Functional\DependencyInjection;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class ServicesPublicPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getServiceIds() as $id) {
+            if (strncmp('fos_http_cache.', $id, 15)) {
+                continue;
+            }
+            if ($container->hasDefinition($id)) {
+                $container->getDefinition($id)->setPublic(true);
+            } elseif ($container->hasAlias($id)) {
+                $container->getAlias($id)->setPublic(true);
+            }
+        }
+    }
+}

--- a/tests/Functional/Fixtures/app/AppKernel.php
+++ b/tests/Functional/Fixtures/app/AppKernel.php
@@ -56,6 +56,11 @@ class AppKernel extends Kernel
      */
     public function registerContainerConfiguration(LoaderInterface $loader)
     {
+        if (isset($_ENV['KERNEL_CONFIG']) && $_ENV['KERNEL_CONFIG']) {
+            $loader->load(__DIR__.'/config/'.$_ENV['KERNEL_CONFIG']);
+        } else {
+            $loader->load(__DIR__.'/config/config.yml');
+        }
         if (\version_compare(Kernel::VERSION, '5.0', '>=')) {
             $loader->load(__DIR__.'/config/config_50.yml');
         } elseif (\version_compare(Kernel::VERSION, '4.1', '>=')) {

--- a/tests/Functional/Fixtures/app/config/config3.yml
+++ b/tests/Functional/Fixtures/app/config/config3.yml
@@ -1,6 +1,3 @@
-imports:
-  - { resource: config.yml }
-
 framework:
   router:
     resource: "%kernel.root_dir%/config/routing.yml"

--- a/tests/Functional/Fixtures/app/config/config_41.yml
+++ b/tests/Functional/Fixtures/app/config/config_41.yml
@@ -1,8 +1,5 @@
 # configuration to make symfony 4.1 work as expected
 
-imports:
-  - { resource: config.yml }
-
 framework:
   router:
     resource: "%kernel.project_dir%/tests/Functional/Fixtures/app/config/routing_41.yml"

--- a/tests/Functional/Fixtures/app/config/config_50.yml
+++ b/tests/Functional/Fixtures/app/config/config_50.yml
@@ -1,8 +1,5 @@
 # configuration to make symfony 5.0 work as expected
 
-imports:
-  - { resource: config.yml }
-
 framework:
   router:
     resource: "%kernel.project_dir%/tests/Functional/Fixtures/app/config/routing_41.yml"

--- a/tests/Functional/Fixtures/app/config/config_servers_from_env.yml
+++ b/tests/Functional/Fixtures/app/config/config_servers_from_env.yml
@@ -1,0 +1,8 @@
+framework:
+  secret: fos
+
+fos_http_cache:
+  proxy_client:
+    varnish:
+      http:
+        servers_from_jsonenv: '%env(json:VARNISH_SERVERS)%'


### PR DESCRIPTION
There was an error in the configuration definition for `servers_from_jsonenv`: 
The variable was defined as scalarNode, however as the environment variable would be marked as 'json' it would yield in an error 'Array not allowed'. If the incoming env var would be a string, then it would yield later in an error, because an array is expected.

So the proposition is to loosen up the configuration definition and use `variableNode`. This is basically the only change I made.

In addition I added an integration test, to see, if an environment variable is correctly injected into HttpDispatcher. However the test doesn't follow best practice as it needs reflection to get access to the servers variable. I can remove the test if you think it doesn't add additional value.