### PR TITLE
Fix test cases for user context listener with different http basic authentication

### DIFF
--- a/tests/Functional/EventListener/UserContextListenerTest.php
+++ b/tests/Functional/EventListener/UserContextListenerTest.php
@@ -16,12 +16,15 @@ use Symfony\Component\HttpFoundation\Session\SessionInterface;
 
 class UserContextListenerTest extends WebTestCase
 {
-    public function testHashLookup()
+    /**
+     * @dataProvider userHashDataProvider
+     */
+    public function testHashLookup(string $username, string $hash)
     {
-        $client = static::createClient([], [
-            'PHP_AUTH_USER' => 'user',
-            'PHP_AUTH_PW' => 'user',
-        ]);
+        $client = static::createClient([], $username ? [
+            'PHP_AUTH_USER' => $username,
+            'PHP_AUTH_PW' => $username,
+        ] : []);
         /** @var SessionInterface $session */
         $session = $client->getContainer()->get('session');
         $session->setId('test');
@@ -33,23 +36,33 @@ class UserContextListenerTest extends WebTestCase
         $response = $client->getResponse();
 
         $this->assertTrue($response->headers->has('X-User-Context-Hash'), 'X-User-Context-Hash header missing on the response');
-        $this->assertEquals('5224d8f5b85429624e2160e538a3376a479ec87b89251b295c44ecbf7498ea3c', $response->headers->get('X-User-Context-Hash'), 'Not the expected context hash');
+        $this->assertEquals($hash, $response->headers->get('X-User-Context-Hash'), 'Not the expected context hash');
         $this->assertEquals('fos_http_cache_hashlookup-test', $response->headers->get('X-Cache-Tags'));
         $this->assertEquals('max-age=60, public', $response->headers->get('Cache-Control'));
     }
 
-    public function testSessionCanBeCached()
+    /**
+     * @dataProvider userHashDataProvider
+     */
+    public function testSessionCanBeCached(string $username, string $hash)
     {
-        $client = static::createClient([], [
-            'PHP_AUTH_USER' => 'user',
-            'PHP_AUTH_PW' => 'user',
-        ]);
+        $client = static::createClient([], $username ? [
+            'PHP_AUTH_USER' => $username,
+            'PHP_AUTH_PW' => $username,
+        ] : []);
         $client->request('GET', '/secured_area/cached_session', [], [], [
-            'HTTP_X-User-Context-Hash' => '5224d8f5b85429624e2160e538a3376a479ec87b89251b295c44ecbf7498ea3c',
+            'HTTP_X-User-Context-Hash' => $hash,
         ]);
         $response = $client->getResponse();
 
         $this->assertTrue($response->isSuccessful());
         $this->assertEquals('max-age=60, public', $response->headers->get('Cache-Control'));
+    }
+
+    public function userHashDataProvider()
+    {
+        yield ['', '5224d8f5b85429624e2160e538a3376a479ec87b89251b295c44ecbf7498ea3c'];
+        yield ['user', '14cea38921d7f2284a52ac67eafb9ed5d30bed84684711591747d9110cae8be9'];
+        yield ['admin', '0878038c198f135419a0ac4df7ecc61b8113b6ef681711f1a5e4aff72616d601'];
     }
 }

--- a/tests/Functional/Fixtures/app/config/config.yml
+++ b/tests/Functional/Fixtures/app/config/config.yml
@@ -77,6 +77,7 @@ security:
     secured_area:
       pattern:    ^/secured_area
       anonymous:
+      http_basic: true
       switch_user: true
       logout:
         path:     /secured_area/logout


### PR DESCRIPTION
While debugging Symfony 6 test case. I did found out that the authentication does on the existing master branch not work like expected.

The test is actually sending `user` as username but actually if you debug and output: https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/blob/36159bbac615d0e4e804d1c43e9ef88123f6a82b/src/UserContext/RoleProvider.php#L60

It is just empty. That is because http_basic is not activated and so the user not logged in.

So the hash which was actually tested is incorrect for `user` and is the hash for not `user`. I addded a data provider so a test runs against different users.