### PR TITLE
lock jinja2 version to avoid BC break

### DIFF
--- a/Resources/doc/requirements.txt
+++ b/Resources/doc/requirements.txt
@@ -1,7 +1,8 @@
 sphinx==1.8.5
 git+https://github.com/fabpot/sphinx-php.git
-sphinx-rtd-theme
+sphinx-rtd-theme==1.0.0
 sphinxcontrib-spelling
 sphinxcontrib-phpdomain
 pyenchant
 docutils==0.17.1
+jinja2<3.1.0


### PR DESCRIPTION
as explained in https://github.com/readthedocs/readthedocs.org/issues/9037