### PR TITLE
fix(deprecation) Fix warning about service config

### DIFF
--- a/src/Resources/config/user_context_legacy.xml
+++ b/src/Resources/config/user_context_legacy.xml
@@ -7,7 +7,7 @@
     <services>
         <service id="fos_http_cache.user_context.logout_handler" class="FOS\HttpCacheBundle\Security\Http\Logout\ContextInvalidationLogoutHandler" public="false">
             <argument type="service" id="fos_http_cache.user_context_invalidator" />
-            <deprecated>The "%service_id%" service is deprecated since 2.2 and will be removed in 3.0.</deprecated>
+            <deprecated version="2.2" package="friendsofsymfony/http-cache-bundle">The "%service_id%" service is deprecated since 2.2 and will be removed in 3.0.</deprecated>
         </service>
     </services>
 </container>


### PR DESCRIPTION
This fixes the warning reported by SF 5.4 when using the legacy context (this is similar to what done in user_context_legacy_sf6.xml)

Humm, looks like SF 4.x complains about an invalid element.. will check that later :)