### PR TITLE
Fix several deprecation notices

### DIFF
--- a/src/Configuration/InvalidatePath.php
+++ b/src/Configuration/InvalidatePath.php
@@ -66,7 +66,7 @@ class InvalidatePath extends ConfigurationAnnotation
     /**
      * {@inheritdoc}
      */
-    public function getAliasName()
+    public function getAliasName(): string
     {
         return 'invalidate_path';
     }
@@ -74,7 +74,7 @@ class InvalidatePath extends ConfigurationAnnotation
     /**
      * {@inheritdoc}
      */
-    public function allowArray()
+    public function allowArray(): bool
     {
         return true;
     }

--- a/src/Configuration/InvalidateRoute.php
+++ b/src/Configuration/InvalidateRoute.php
@@ -115,7 +115,7 @@ class InvalidateRoute extends ConfigurationAnnotation
     /**
      * {@inheritdoc}
      */
-    public function getAliasName()
+    public function getAliasName(): string
     {
         return 'invalidate_route';
     }
@@ -123,7 +123,7 @@ class InvalidateRoute extends ConfigurationAnnotation
     /**
      * {@inheritdoc}
      */
-    public function allowArray()
+    public function allowArray(): bool
     {
         return true;
     }

--- a/src/Configuration/Tag.php
+++ b/src/Configuration/Tag.php
@@ -92,7 +92,7 @@ class Tag extends ConfigurationAnnotation
     /**
      * {@inheritdoc}
      */
-    public function getAliasName()
+    public function getAliasName(): string
     {
         return 'tag';
     }
@@ -100,7 +100,7 @@ class Tag extends ConfigurationAnnotation
     /**
      * {@inheritdoc}
      */
-    public function allowArray()
+    public function allowArray(): bool
     {
         return true;
     }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -51,7 +51,7 @@ class Configuration implements ConfigurationInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfigTreeBuilder()
+    public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('fos_http_cache');
 

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -17,6 +17,7 @@ use FOS\HttpCache\SymfonyCache\KernelDispatcher;
 use FOS\HttpCache\TagHeaderFormatter\MaxHeaderValueLengthFormatter;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use FOS\HttpCacheBundle\Http\ResponseMatcher\ExpressionResponseMatcher;
+use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\Console\Application;
@@ -37,7 +38,7 @@ class FOSHttpCacheExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function getConfiguration(array $config, ContainerBuilder $container)
+    public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface
     {
         return new Configuration($container->getParameter('kernel.debug'));
     }

--- a/src/EventListener/CacheControlListener.php
+++ b/src/EventListener/CacheControlListener.php
@@ -79,7 +79,7 @@ class CacheControlListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => ['onKernelResponse', 10],

--- a/src/EventListener/FlashMessageListener.php
+++ b/src/EventListener/FlashMessageListener.php
@@ -65,7 +65,7 @@ final class FlashMessageListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/src/EventListener/InvalidationListener.php
+++ b/src/EventListener/InvalidationListener.php
@@ -141,7 +141,7 @@ class InvalidationListener extends AbstractRuleListener implements EventSubscrib
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::TERMINATE => 'onKernelTerminate',

--- a/src/EventListener/Php8AttributesListener.php
+++ b/src/EventListener/Php8AttributesListener.php
@@ -76,7 +76,10 @@ class Php8AttributesListener implements EventSubscriberInterface
         }
     }
 
-    public static function getSubscribedEvents()
+    /**
+     * {@inheritdoc}
+     */
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::REQUEST => 'onKernelRequest',

--- a/src/EventListener/TagListener.php
+++ b/src/EventListener/TagListener.php
@@ -123,7 +123,7 @@ class TagListener extends AbstractRuleListener implements EventSubscriberInterfa
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/src/EventListener/UserContextListener.php
+++ b/src/EventListener/UserContextListener.php
@@ -256,7 +256,7 @@ class UserContextListener implements EventSubscriberInterface
     /**
      * {@inheritdoc}
      */
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
             KernelEvents::RESPONSE => 'onKernelResponse',

--- a/src/Twig/CacheTagExtension.php
+++ b/src/Twig/CacheTagExtension.php
@@ -33,7 +33,7 @@ class CacheTagExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getFunctions()
+    public function getFunctions(): array
     {
         return [
             new TwigFunction('fos_httpcache_tag', [$this, 'addTag']),
@@ -55,10 +55,7 @@ class CacheTagExtension extends AbstractExtension
         $this->responseTagger->addTags((array) $tag);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function getName()
+    public function getName(): string
     {
         return 'fos_httpcache_tag_extension';
     }


### PR DESCRIPTION
This fixes several deprecation notices:

```
Method "Twig\Extension\ExtensionInterface::getFunctions()" might add "array" as a native return type declaration in the future. Do the same in implementation "FOS\HttpCacheBundle\Twig\CacheTagExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\EventDispatcher\EventSubscriberInterface::getSubscribedEvents()" might add "array" as a native return type declaration in the future. Do the same in implementation "FOS\HttpCacheBundle\EventListener\CacheControlListener" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\Config\Definition\ConfigurationInterface::getConfigTreeBuilder()" might add "TreeBuilder" as a native return type declaration in the future. Do the same in implementation "FOS\HttpCacheBundle\DependencyInjection\Configuration" now to avoid errors or add an explicit @return annotation to suppress this message.

Method "Symfony\Component\DependencyInjection\Extension\ConfigurationExtensionInterface::getConfiguration()" might add "?ConfigurationInterface" as a native return type declaration in the future. Do the same in implementation "FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension" now to avoid errors or add an explicit @return annotation to suppress this message. 

User Deprecated: Method "Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface::getAliasName()" might add "string" as a native return type declaration in the future. Do the same in implementation "FOS\HttpCacheBundle\Configuration\Tag" now to avoid errors or add an explicit @return annotation to suppress this message. 

User Deprecated: Method "Sensio\Bundle\FrameworkExtraBundle\Configuration\ConfigurationInterface::allowArray()" might add "bool" as a native return type declaration in the future. Do the same in implementation "FOS\HttpCacheBundle\Configuration\Tag" now to avoid errors or add an explicit @return annotation to suppress this message. 
```