### PR TITLE
Replace deprecated Command::$defaultName

### DIFF
--- a/src/Command/ClearCommand.php
+++ b/src/Command/ClearCommand.php
@@ -12,7 +12,7 @@
 namespace FOS\HttpCacheBundle\Command;
 
 use FOS\HttpCache\CacheInvalidator;
-use FOS\HttpCacheBundle\CacheManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -21,22 +21,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author Alexander Schranz <alexander@sulu.io>
  */
+#[AsCommand(name: 'fos:httpcache:clear')]
 class ClearCommand extends BaseInvalidateCommand
 {
     use PathSanityCheck;
-
-    protected static $defaultName = 'fos:httpcache:clear';
-
-    /**
-     * If no cache manager is specified explicitly, fos_http_cache.cache_manager
-     * is automatically loaded.
-     *
-     * @param CacheManager|null $cacheManager The cache manager to talk to
-     */
-    public function __construct(CacheManager $cacheManager = null)
-    {
-        parent::__construct($cacheManager);
-    }
 
     /**
      * {@inheritdoc}
@@ -44,6 +32,7 @@ class ClearCommand extends BaseInvalidateCommand
     protected function configure()
     {
         $this
+            ->setName('fos:httpcache:clear')
             ->setDescription('Clear the HTTP cache.')
             ->setHelp(
                 <<<'EOF'

--- a/src/Command/InvalidatePathCommand.php
+++ b/src/Command/InvalidatePathCommand.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCacheBundle\Command;
 
 use FOS\HttpCacheBundle\CacheManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -21,11 +22,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
+#[AsCommand(name: 'fos:httpcache:invalidate:path')]
 class InvalidatePathCommand extends BaseInvalidateCommand
 {
     use PathSanityCheck;
-
-    protected static $defaultName = 'fos:httpcache:invalidate:path';
 
     /**
      * If no cache manager is specified explicitly, fos_http_cache.cache_manager
@@ -35,11 +35,12 @@ class InvalidatePathCommand extends BaseInvalidateCommand
      */
     public function __construct(CacheManager $cacheManager = null)
     {
+        parent::__construct($cacheManager);
+
         if (2 <= func_num_args()) {
             @trigger_error('Passing a command name in the constructor is deprecated and will be removed in version 3', E_USER_DEPRECATED);
-            static::$defaultName = func_get_arg(1);
+            $this->setName(func_get_arg(1));
         }
-        parent::__construct($cacheManager);
     }
 
     /**
@@ -48,6 +49,7 @@ class InvalidatePathCommand extends BaseInvalidateCommand
     protected function configure()
     {
         $this
+            ->setName('fos:httpcache:invalidate:path')
             ->setDescription('Invalidate cached paths on all configured caching proxies')
             ->addArgument(
                 'paths',

--- a/src/Command/InvalidateRegexCommand.php
+++ b/src/Command/InvalidateRegexCommand.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCacheBundle\Command;
 
 use FOS\HttpCacheBundle\CacheManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -22,10 +23,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  * @author Christian Stocker <chregu@liip.ch>
  * @author David Buchmann <mail@davidbu.ch>
  */
+#[AsCommand(name: 'fos:httpcache:invalidate:regex')]
 class InvalidateRegexCommand extends BaseInvalidateCommand
 {
-    protected static $defaultName = 'fos:httpcache:invalidate:regex';
-
     /**
      * If no cache manager is specified explicitly, fos_http_cache.cache_manager
      * is automatically loaded.
@@ -34,11 +34,12 @@ class InvalidateRegexCommand extends BaseInvalidateCommand
      */
     public function __construct(CacheManager $cacheManager = null, $commandName = 'fos:httpcache:invalidate:regex')
     {
+        parent::__construct($cacheManager);
+
         if (2 <= func_num_args()) {
             @trigger_error('Passing a command name in the constructor is deprecated and will be removed in version 3', E_USER_DEPRECATED);
-            static::$defaultName = func_get_arg(1);
+            $this->setName(func_get_arg(1));
         }
-        parent::__construct($cacheManager);
     }
 
     /**
@@ -47,6 +48,7 @@ class InvalidateRegexCommand extends BaseInvalidateCommand
     protected function configure()
     {
         $this
+            ->setName('fos:httpcache:invalidate:regex')
             ->setDescription('Invalidate everything matching a regular expression on all configured caching proxies')
             ->addArgument(
                 'regex',

--- a/src/Command/InvalidateTagCommand.php
+++ b/src/Command/InvalidateTagCommand.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCacheBundle\Command;
 
 use FOS\HttpCacheBundle\CacheManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -21,10 +22,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
+#[AsCommand(name: 'fos:httpcache:invalidate:tag')]
 class InvalidateTagCommand extends BaseInvalidateCommand
 {
-    protected static $defaultName = 'fos:httpcache:invalidate:tag';
-
     /**
      * If no cache manager is specified explicitly, fos_http_cache.cache_manager
      * is automatically loaded.
@@ -33,11 +33,12 @@ class InvalidateTagCommand extends BaseInvalidateCommand
      */
     public function __construct(CacheManager $cacheManager = null, $commandName = 'fos:httpcache:invalidate:tag')
     {
+        parent::__construct($cacheManager);
+
         if (2 <= func_num_args()) {
             @trigger_error('Passing a command name in the constructor is deprecated and will be removed in version 3', E_USER_DEPRECATED);
-            static::$defaultName = func_get_arg(1);
+            $this->setName(func_get_arg(1));
         }
-        parent::__construct($cacheManager);
     }
 
     /**
@@ -46,6 +47,7 @@ class InvalidateTagCommand extends BaseInvalidateCommand
     protected function configure()
     {
         $this
+            ->setName('fos:httpcache:invalidate:tag')
             ->setDescription('Invalidate cached content matching the specified tags on all configured caching proxies')
             ->addArgument(
                 'tags',

--- a/src/Command/RefreshPathCommand.php
+++ b/src/Command/RefreshPathCommand.php
@@ -12,6 +12,7 @@
 namespace FOS\HttpCacheBundle\Command;
 
 use FOS\HttpCacheBundle\CacheManager;
+use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -21,11 +22,10 @@ use Symfony\Component\Console\Output\OutputInterface;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
+#[AsCommand(name: 'fos:httpcache:refresh:path')]
 class RefreshPathCommand extends BaseInvalidateCommand
 {
     use PathSanityCheck;
-
-    protected static $defaultName = 'fos:httpcache:refresh:path';
 
     /**
      * If no cache manager is specified explicitly, fos_http_cache.cache_manager
@@ -35,11 +35,12 @@ class RefreshPathCommand extends BaseInvalidateCommand
      */
     public function __construct(CacheManager $cacheManager = null)
     {
+        parent::__construct($cacheManager);
+
         if (2 <= func_num_args()) {
             @trigger_error('Passing a command name in the constructor is deprecated and will be removed in version 3', E_USER_DEPRECATED);
-            static::$defaultName = func_get_arg(1);
+            $this->setName(func_get_arg(1));
         }
-        parent::__construct($cacheManager);
     }
 
     /**
@@ -48,6 +49,7 @@ class RefreshPathCommand extends BaseInvalidateCommand
     protected function configure()
     {
         $this
+            ->setName('fos:httpcache:refresh:path')
             ->setDescription('Refresh paths on all configured caching proxies')
             ->addArgument(
                 'paths',


### PR DESCRIPTION
The use of `Command::$defaultName` is deprecate since Symfony 6.1: https://github.com/symfony/symfony/blob/6.2/UPGRADE-6.1.md