### PR TITLE
Add CloudFront support

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -21,6 +21,7 @@ jobs:
           - php-version: '7.4'
           - php-version: '8.0'
           - php-version: '8.1'
+            dependencies: 'jean-beru/fos-http-cache-cloudfront'
           - php-version: '7.4'
             symfony-version: '4.*'
           - php-version: '7.4'

--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -278,6 +278,7 @@ endpoint for testing purposes.
 
 cloudfront
 ----------
+Talking to AWS cloudfront requires the ``jean-beru/fos-http-cache-cloudfront`` library. You need to require this dependency before you can configure the ``cloudfront`` proxy client.
 
 .. code-block:: yaml
 

--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -276,6 +276,54 @@ endpoint for testing purposes.
 
 .. _configuration_noop_proxy_client:
 
+cloudfront
+----------
+
+.. code-block:: yaml
+
+    # config/packages/fos_http_cache.yaml
+    fos_http_cache:
+        proxy_client:
+            cloudfront:
+                distribution_id: '<my-distribution-id>'
+                configuration:
+                    accessKeyId: '<my-access-key-id>'
+                    accessKeySecret: '<my-access-key-secret>'
+
+.. code-block:: yaml
+
+    # config/packages/fos_http_cache.yaml
+    fos_http_cache:
+        proxy_client:
+            cloudfront:
+                distribution_id: '<my-distribution-id>'
+                client: '<my.custom.client>'
+
+``distribution_id``
+"""""""""""""""""""
+
+**type**: ``string``
+
+Identifier for the CloudFront distribution you want to purge the cache for.
+
+``configuration``
+"""""""""""""""""
+
+**type**: ``array`` **default**: ``[]``
+
+Configuration used to instantiate the `AsyncAws\CloudFront\CloudFrontClient` client. More information is available on
+the `AWS Async documentation_`. It can not be used with the ``client`` option.
+
+``client``
+"""""""""""""""""
+
+**type**: ``string`` **default**: ``null``
+
+Service identifier of a `AsyncAws\CloudFront\CloudFrontClient` client. More information is available on the
+`AWS Async documentation_`. It can not be used with the ``configuration`` option.
+
+.. _configuration_noop_proxy_client:
+
 noop
 ----
 
@@ -328,3 +376,4 @@ bundle. Please refer to the :ref:`FOSHttpCache library’s documentation <foshtt
 for more information.
 
 .. _xkey vmod: https://github.com/varnish/varnish-modules/blob/master/docs/vmod_xkey.rst
+.. _AWS Async documentation_: https://async-aws.com/configuration.html

--- a/Resources/doc/spelling_word_list.txt
+++ b/Resources/doc/spelling_word_list.txt
@@ -6,6 +6,7 @@ autoconfigured
 backend
 cacheable
 cloudflare
+cloudfront
 ETag
 friendsofsymfony
 github

--- a/composer.json
+++ b/composer.json
@@ -50,8 +50,7 @@
         "symfony/monolog-bundle": "^3.0",
         "symfony/routing": "^4.4 || ^5.0 || ^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "sebastian/exporter": "^2.0",
-        "jean-beru/fos-http-cache-cloudfront": "^1.0"
+        "sebastian/exporter": "^2.0"
     },
     "suggest": {
         "jean-beru/fos-http-cache-cloudfront": "To use CloudFront proxy",

--- a/composer.json
+++ b/composer.json
@@ -50,9 +50,11 @@
         "symfony/monolog-bundle": "^3.0",
         "symfony/routing": "^4.4 || ^5.0 || ^6.0",
         "matthiasnoback/symfony-dependency-injection-test": "^4.0",
-        "sebastian/exporter": "^2.0"
+        "sebastian/exporter": "^2.0",
+        "jean-beru/fos-http-cache-cloudfront": "^1.0"
     },
     "suggest": {
+        "jean-beru/fos-http-cache-cloudfront": "To use CloudFront proxy",
         "sensio/framework-extra-bundle": "For Tagged Cache Invalidation",
         "symfony/expression-language": "For Tagged Cache Invalidation",
         "symfony/console": "To send invalidation requests from the command line"

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -496,6 +496,7 @@ class Configuration implements ConfigurationInterface
                         ->end()
 
                         ->arrayNode('cloudfront')
+                            ->info('Configure a client to interact with AWS cloudfront. You need to install jean-beru/fos-http-cache-cloudfront to work with cloudfront')
                             ->children()
                                 ->scalarNode('distribution_id')
                                     ->info('Identifier for your CloudFront distribution you want to purge the cache for')
@@ -511,7 +512,7 @@ class Configuration implements ConfigurationInterface
                             ->end()
                             ->validate()
                                 ->ifTrue(function ($v) {
-                                    return !empty($v['client']) && !empty($v['configuration']);
+                                    return null !== $v['client'] && count($v['configuration']) > 0;
                                 })
                                 ->thenInvalid('You can not set both cloudfront.client and cloudfront.configuration')
                             ->end()
@@ -551,7 +552,7 @@ class Configuration implements ConfigurationInterface
 
                                 if ('cloudfront' === $proxyName) {
                                     if (!class_exists(CloudFront::class)) {
-                                        throw new InvalidConfigurationException('Did you forget to install jean-beru/fos-http-cache-cloudfront ?');
+                                        throw new InvalidConfigurationException('For the cloudfront proxy client, you need to install jean-beru/fos-http-cache-cloudfront. Class '.CloudFront::class.' does not exist.');
                                     }
                                 }
                             }

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -764,7 +764,7 @@ class Configuration implements ConfigurationInterface
                                     ->thenInvalid('Configured a tag_expression but ExpressionLanugage is not available')
                                 ->end()
                                 ->children()
-                        ;
+        ;
         $this->addMatch($rules);
 
         $rules

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -18,7 +18,6 @@ use FOS\HttpCache\SymfonyCache\KernelDispatcher;
 use FOS\HttpCache\TagHeaderFormatter\MaxHeaderValueLengthFormatter;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use FOS\HttpCacheBundle\Http\ResponseMatcher\ExpressionResponseMatcher;
-use JeanBeru\HttpCacheCloudFront\Proxy\CloudFront;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
@@ -92,7 +91,7 @@ class FOSHttpCacheExtension extends Extension
                     if ('noop' !== $defaultClient
                         && array_key_exists('base_url', $config['proxy_client'][$defaultClient])) {
                         $generateUrlType = UrlGeneratorInterface::ABSOLUTE_PATH;
-                    } elseif('cloudfront' === $defaultClient) {
+                    } elseif ('cloudfront' === $defaultClient) {
                         $generateUrlType = UrlGeneratorInterface::ABSOLUTE_PATH;
                     } else {
                         $generateUrlType = UrlGeneratorInterface::ABSOLUTE_URL;

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -11,12 +11,14 @@
 
 namespace FOS\HttpCacheBundle\DependencyInjection;
 
+use AsyncAws\CloudFront\CloudFrontClient;
 use FOS\HttpCache\ProxyClient\HttpDispatcher;
 use FOS\HttpCache\ProxyClient\ProxyClient;
 use FOS\HttpCache\SymfonyCache\KernelDispatcher;
 use FOS\HttpCache\TagHeaderFormatter\MaxHeaderValueLengthFormatter;
 use FOS\HttpCacheBundle\DependencyInjection\Compiler\HashGeneratorPass;
 use FOS\HttpCacheBundle\Http\ResponseMatcher\ExpressionResponseMatcher;
+use JeanBeru\HttpCacheCloudFront\Proxy\CloudFront;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
 use Symfony\Component\Config\FileLocator;
@@ -89,6 +91,8 @@ class FOSHttpCacheExtension extends Extension
                     $defaultClient = $this->getDefaultProxyClient($config['proxy_client']);
                     if ('noop' !== $defaultClient
                         && array_key_exists('base_url', $config['proxy_client'][$defaultClient])) {
+                        $generateUrlType = UrlGeneratorInterface::ABSOLUTE_PATH;
+                    } elseif('cloudfront' === $defaultClient) {
                         $generateUrlType = UrlGeneratorInterface::ABSOLUTE_PATH;
                     } else {
                         $generateUrlType = UrlGeneratorInterface::ABSOLUTE_URL;
@@ -340,6 +344,9 @@ class FOSHttpCacheExtension extends Extension
         if (isset($config['cloudflare'])) {
             $this->loadCloudflare($container, $loader, $config['cloudflare']);
         }
+        if (isset($config['cloudfront'])) {
+            $this->loadCloudfront($container, $loader, $config['cloudfront']);
+        }
         if (isset($config['noop'])) {
             $loader->load('noop.xml');
         }
@@ -469,6 +476,27 @@ class FOSHttpCacheExtension extends Extension
         $container->setParameter('fos_http_cache.proxy_client.cloudflare.options', $options);
 
         $loader->load('cloudflare.xml');
+    }
+
+    private function loadCloudfront(ContainerBuilder $container, XmlFileLoader $loader, array $config)
+    {
+        if (null !== $config['client']) {
+            $container->setAlias(
+                'fos_http_cache.proxy_client.cloudfront.cloudfront_client',
+                $config['client']
+            );
+        } else {
+            $container->setDefinition(
+                'fos_http_cache.proxy_client.cloudfront.cloudfront_client',
+                new Definition(CloudFrontClient::class, [$config['configuration']])
+            );
+        }
+
+        $container->setParameter('fos_http_cache.proxy_client.cloudfront.options', [
+            'distribution_id' => $config['distribution_id'],
+        ]);
+
+        $loader->load('cloudfront.xml');
     }
 
     /**
@@ -627,6 +655,10 @@ class FOSHttpCacheExtension extends Extension
 
         if (isset($config['cloudflare'])) {
             return 'cloudflare';
+        }
+
+        if (isset($config['cloudfront'])) {
+            return 'cloudfront';
         }
 
         if (isset($config['noop'])) {

--- a/src/Resources/config/cloudfront.xml
+++ b/src/Resources/config/cloudfront.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_http_cache.proxy_client.cloudfront"
+                 class="JeanBeru\HttpCacheCloudFront\Proxy\CloudFront"
+                 public="true">
+            <argument type="service" id="fos_http_cache.proxy_client.cloudfront.cloudfront_client"/>
+            <argument>%fos_http_cache.proxy_client.cloudfront.options%</argument>
+        </service>
+    </services>
+
+</container>

--- a/tests/Resources/Fixtures/config/cloudfront.php
+++ b/tests/Resources/Fixtures/config/cloudfront.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * This file is part of the FOSHttpCacheBundle package.
+ *
+ * (c) FriendsOfSymfony <http://friendsofsymfony.github.com/>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+$container->loadFromExtension('fos_http_cache', [
+    'proxy_client' => [
+        'cloudfront' => [
+            'distribution_id' => 'my_distribution',
+            'configuration' => ['accessKeyId' => 'AwsAccessKeyId', 'accessKeySecret' => 'AwsAccessKeySecret'],
+        ],
+    ],
+]);

--- a/tests/Resources/Fixtures/config/cloudfront.xml
+++ b/tests/Resources/Fixtures/config/cloudfront.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<container xmlns="http://symfony.com/schema/dic/services">
+
+    <config xmlns="http://example.org/schema/dic/fos_http_cache">
+        <proxy-client>
+            <cloudfront distribution-id="my_distribution">
+                <configuration>
+                    <accessKeyId>AwsAccessKeyId</accessKeyId>
+                    <accessKeySecret>AwsAccessKeySecret</accessKeySecret>
+                </configuration>
+            </cloudfront>
+        </proxy-client>
+
+    </config>
+</container>

--- a/tests/Resources/Fixtures/config/cloudfront.yml
+++ b/tests/Resources/Fixtures/config/cloudfront.yml
@@ -1,0 +1,8 @@
+fos_http_cache:
+
+    proxy_client:
+        cloudfront:
+            distribution_id: 'my_distribution'
+            configuration:
+                accessKeyId: 'AwsAccessKeyId'
+                accessKeySecret: 'AwsAccessKeySecret'

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\Tests\Unit\DependencyInjection;
 
 use FOS\HttpCacheBundle\DependencyInjection\Configuration;
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
+use JeanBeru\HttpCacheCloudFront\Proxy\CloudFront;
 use Matthias\SymfonyDependencyInjectionTest\PhpUnit\AbstractExtensionConfigurationTestCase;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -329,6 +330,10 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 
     public function testSupportsCloudfront()
     {
+        if (!class_exists(CloudFront::class)) {
+            $this->markTestSkipped('jean-beru/fos-http-cache-cloudfront not available');
+        }
+
         $expectedConfiguration = $this->getEmptyConfig();
         $expectedConfiguration['proxy_client'] = [
             'cloudfront' => [
@@ -357,6 +362,10 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
 
     public function testCloudfrontConfigurationWithClientIsNotAllowed()
     {
+        if (!class_exists(CloudFront::class)) {
+            $this->markTestSkipped('jean-beru/fos-http-cache-cloudfront not available');
+        }
+
         $this->expectException(InvalidConfigurationException::class);
         $this->expectExceptionMessage('You can not set both cloudfront.client and cloudfront.configuration');
 

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -327,6 +327,52 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
         }
     }
 
+    public function testSupportsCloudfront()
+    {
+        $expectedConfiguration = $this->getEmptyConfig();
+        $expectedConfiguration['proxy_client'] = [
+            'cloudfront' => [
+                'distribution_id' => 'my_distribution',
+                'configuration' => ['accessKeyId' => 'AwsAccessKeyId', 'accessKeySecret' => 'AwsAccessKeySecret'],
+                'client' => null,
+            ],
+        ];
+        $expectedConfiguration['cache_manager']['enabled'] = 'auto';
+        $expectedConfiguration['cache_manager']['generate_url_type'] = 'auto';
+        $expectedConfiguration['tags']['enabled'] = 'auto';
+        $expectedConfiguration['invalidation']['enabled'] = 'auto';
+
+        $formats = array_map(function ($path) {
+            return __DIR__.'/../../Resources/Fixtures/'.$path;
+        }, [
+            'config/cloudfront.yml',
+            'config/cloudfront.xml',
+            'config/cloudfront.php',
+        ]);
+
+        foreach ($formats as $format) {
+            $this->assertProcessedConfigurationEquals($expectedConfiguration, [$format]);
+        }
+    }
+
+    public function testCloudfrontConfigurationWithClientIsNotAllowed()
+    {
+        $this->expectException(InvalidConfigurationException::class);
+        $this->expectExceptionMessage('You can not set both cloudfront.client and cloudfront.configuration');
+
+        $params = $this->getEmptyConfig();
+        $params['proxy_client'] = [
+            'cloudfront' => [
+                'distribution_id' => 'my_distribution',
+                'configuration' => ['accessKeyId' => 'AwsAccessKeyId', 'accessKeySecret' => 'AwsAccessKeySecret'],
+                'client' => 'my.client',
+            ],
+        ];
+
+        $configuration = new Configuration(false);
+        (new Processor())->processConfiguration($configuration, ['fos_http_cache' => $params]);
+    }
+
     public function testEmptyServerConfigurationIsNotAllowed()
     {
         $this->expectException(InvalidConfigurationException::class);

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\Tests\Unit\DependencyInjection;
 
 use FOS\HttpCache\SymfonyCache\KernelDispatcher;
 use FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension;
+use JeanBeru\HttpCacheCloudFront\Proxy\CloudFront;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -168,6 +169,10 @@ class FOSHttpCacheExtensionTest extends TestCase
 
     public function testConfigLoadCloudfront()
     {
+        if (!class_exists(CloudFront::class)) {
+            $this->markTestSkipped('jean-beru/fos-http-cache-cloudfront not available');
+        }
+
         $container = $this->createContainer();
         $this->extension->load([
             [
@@ -190,6 +195,10 @@ class FOSHttpCacheExtensionTest extends TestCase
 
     public function testConfigLoadCloudfrontWithClient()
     {
+        if (!class_exists(CloudFront::class)) {
+            $this->markTestSkipped('jean-beru/fos-http-cache-cloudfront not available');
+        }
+
         $container = $this->createContainer();
         $this->extension->load([
             [

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -166,6 +166,51 @@ class FOSHttpCacheExtensionTest extends TestCase
         $this->assertTrue($container->hasDefinition('fos_http_cache.event_listener.invalidation'));
     }
 
+    public function testConfigLoadCloudfront()
+    {
+        $container = $this->createContainer();
+        $this->extension->load([
+            [
+                'proxy_client' => [
+                    'cloudfront' => [
+                        'distribution_id' => 'my_distribution',
+                    ],
+                ],
+            ],
+        ], $container);
+
+        $this->assertFalse($container->hasDefinition('fos_http_cache.proxy_client.varnish'));
+        $this->assertTrue($container->hasDefinition('fos_http_cache.proxy_client.cloudfront.cloudfront_client'));
+        $this->assertTrue($container->hasParameter('fos_http_cache.proxy_client.cloudfront.options'));
+        $this->assertSame(['distribution_id' => 'my_distribution'], $container->getParameter('fos_http_cache.proxy_client.cloudfront.options'));
+        $this->assertTrue($container->hasDefinition('fos_http_cache.proxy_client.cloudfront'));
+        $this->assertTrue($container->hasAlias('fos_http_cache.default_proxy_client'));
+        $this->assertTrue($container->hasDefinition('fos_http_cache.event_listener.invalidation'));
+    }
+
+    public function testConfigLoadCloudfrontWithClient()
+    {
+        $container = $this->createContainer();
+        $this->extension->load([
+            [
+                'proxy_client' => [
+                    'cloudfront' => [
+                        'distribution_id' => 'my_distribution',
+                        'client' => 'my.client',
+                    ],
+                ],
+            ],
+        ], $container);
+
+        $this->assertFalse($container->hasDefinition('fos_http_cache.proxy_client.varnish'));
+        $this->assertTrue($container->hasAlias('fos_http_cache.proxy_client.cloudfront.cloudfront_client'));
+        $this->assertTrue($container->hasParameter('fos_http_cache.proxy_client.cloudfront.options'));
+        $this->assertSame(['distribution_id' => 'my_distribution'], $container->getParameter('fos_http_cache.proxy_client.cloudfront.options'));
+        $this->assertTrue($container->hasDefinition('fos_http_cache.proxy_client.cloudfront'));
+        $this->assertTrue($container->hasAlias('fos_http_cache.default_proxy_client'));
+        $this->assertTrue($container->hasDefinition('fos_http_cache.event_listener.invalidation'));
+    }
+
     public function testConfigLoadNoop()
     {
         $container = $this->createContainer();


### PR DESCRIPTION
This PR adds the support of CloudFront proxy using https://github.com/Jean-Beru/fos-http-cache-cloudfront. See https://github.com/FriendsOfSymfony/FOSHttpCache/issues/542.

This dependency is added in Composer as a "suggest" (and "dev" for testing purpose). We can also discuss about removing it by merging its classes in https://github.com/FriendsOfSymfony/FOSHttpCache.