### PR TITLE
Fix symfony 6.3 return type deprecations

### DIFF
--- a/src/DependencyInjection/Compiler/HashGeneratorPass.php
+++ b/src/DependencyInjection/Compiler/HashGeneratorPass.php
@@ -26,7 +26,7 @@ class HashGeneratorPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has('fos_http_cache.user_context.hash_generator')) {
             return;

--- a/src/DependencyInjection/Compiler/LoggerPass.php
+++ b/src/DependencyInjection/Compiler/LoggerPass.php
@@ -22,7 +22,7 @@ class LoggerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (!$container->has('logger') || !$container->has('fos_http_cache.event_listener.log')) {
             return;

--- a/src/DependencyInjection/Compiler/SessionListenerPass.php
+++ b/src/DependencyInjection/Compiler/SessionListenerPass.php
@@ -25,7 +25,7 @@ class SessionListenerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if ($container->has('session_listener')) {
             return;

--- a/src/DependencyInjection/Compiler/TagListenerPass.php
+++ b/src/DependencyInjection/Compiler/TagListenerPass.php
@@ -23,7 +23,7 @@ class TagListenerPass implements CompilerPassInterface
     /**
      * {@inheritdoc}
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         if (true === $container->getParameter('fos_http_cache.compiler_pass.tag_annotations')
             && !$this->hasControllerListener($container)
@@ -37,7 +37,7 @@ class TagListenerPass implements CompilerPassInterface
         }
     }
 
-    private function hasControllerListener(ContainerBuilder $container)
+    private function hasControllerListener(ContainerBuilder $container): bool
     {
         return $container->has('sensio_framework_extra.controller.listener') ||
             $container->has(ControllerListener::class);

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -47,7 +47,7 @@ class FOSHttpCacheExtension extends Extension
     /**
      * {@inheritdoc}
      */
-    public function load(array $configs, ContainerBuilder $container)
+    public function load(array $configs, ContainerBuilder $container): void
     {
         $configuration = $this->getConfiguration($configs, $container);
         $config = $this->processConfiguration($configuration, $configs);

--- a/src/FOSHttpCacheBundle.php
+++ b/src/FOSHttpCacheBundle.php
@@ -24,7 +24,7 @@ class FOSHttpCacheBundle extends Bundle
     /**
      * {@inheritdoc}
      */
-    public function build(ContainerBuilder $container)
+    public function build(ContainerBuilder $container): void
     {
         $container->addCompilerPass(new LoggerPass());
         $container->addCompilerPass(new TagListenerPass());


### PR DESCRIPTION
> Method "Symfony\Component\DependencyInjection\Extension\ExtensionInterface::load()" might add "void" as a native return type declaration in the future. Do the same in implementation "FOS\HttpCacheBundle\DependencyInjection\FOSHttpCacheExtension" now to avoid errors or add an explicit @return annotation to suppress this message.

(For all compiler passes)
> Method "Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface::process()" might add "void" as a native return type declaration in the future. Do the same in implementation "FOS\HttpCacheBundle\DependencyInjection\Compiler\LoggerPass" now to avoid errors or add an explicit @return annotation to suppress this message.

> User Deprecated: Method "Symfony\Component\HttpKernel\Bundle\Bundle::build()" might add "void" as a native return type declaration in the future. Do the same in child class "FOS\HttpCacheBundle\FOSHttpCacheBundle" now to avoid errors or add an explicit @return annotation to suppress this message.

