### PR TITLE
Fix symfony 6.3 return type deprecations

### DIFF
--- a/src/Command/ClearCommand.php
+++ b/src/Command/ClearCommand.php
@@ -29,7 +29,7 @@ class ClearCommand extends BaseInvalidateCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('fos:httpcache:clear')

--- a/src/Command/InvalidatePathCommand.php
+++ b/src/Command/InvalidatePathCommand.php
@@ -46,7 +46,7 @@ class InvalidatePathCommand extends BaseInvalidateCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('fos:httpcache:invalidate:path')

--- a/src/Command/InvalidateRegexCommand.php
+++ b/src/Command/InvalidateRegexCommand.php
@@ -45,7 +45,7 @@ class InvalidateRegexCommand extends BaseInvalidateCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('fos:httpcache:invalidate:regex')

--- a/src/Command/InvalidateTagCommand.php
+++ b/src/Command/InvalidateTagCommand.php
@@ -44,7 +44,7 @@ class InvalidateTagCommand extends BaseInvalidateCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('fos:httpcache:invalidate:tag')

--- a/src/Command/RefreshPathCommand.php
+++ b/src/Command/RefreshPathCommand.php
@@ -46,7 +46,7 @@ class RefreshPathCommand extends BaseInvalidateCommand
     /**
      * {@inheritdoc}
      */
-    protected function configure()
+    protected function configure(): void
     {
         $this
             ->setName('fos:httpcache:refresh:path')


### PR DESCRIPTION
Fixes the following deprecation errors:

```
Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "FOS\HttpCacheBundle\Command\InvalidatePathCommand" now to avoid errors or add an explicit @return annotation to suppress this message. 

Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "FOS\HttpCacheBundle\Command\InvalidateRegexCommand" now to avoid errors or add an explicit @return annotation to suppress this message. 

Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "FOS\HttpCacheBundle\Command\RefreshPathCommand" now to avoid errors or add an explicit @return annotation to suppress this message. 

Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "FOS\HttpCacheBundle\Command\ClearCommand" now to avoid errors or add an explicit @return annotation to suppress this message. 

Method "Symfony\Component\Console\Command\Command::configure()" might add "void" as a native return type declaration in the future. Do the same in child class "FOS\HttpCacheBundle\Command\InvalidateTagCommand" now to avoid errors or add an explicit @return annotation to suppress this message. 
```