### PR TITLE
SF6: catch SessionNotFoundException

### DIFF
--- a/src/EventListener/FlashMessageListener.php
+++ b/src/EventListener/FlashMessageListener.php
@@ -13,6 +13,7 @@ namespace FOS\HttpCacheBundle\EventListener;
 
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpFoundation\Cookie;
+use Symfony\Component\HttpFoundation\Exception\SessionNotFoundException;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Session\Session;
 use Symfony\Component\HttpKernel\Event\FilterResponseEvent;
@@ -82,7 +83,12 @@ final class FlashMessageListener implements EventSubscriberInterface
             return;
         }
 
-        $session = $this->session ?: $event->getRequest()->getSession();
+        try {
+            $session = $this->session ?: $event->getRequest()->getSession();
+        } catch (SessionNotFoundException $e) {
+            return;
+        }
+
         if (null === $session) {
             return;
         }


### PR DESCRIPTION
Since SF6 `getSession` is throwing, rather than a nullable (but i kept it for BC)

This handles it.

We noticed `Session not found` error on http://, since this listener runs before redirecting to https://