### PR TITLE
Fix compiling container using Secrets

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "friendsofsymfony/http-cache": "^2.15",
         "symfony/framework-bundle": "^4.4.0 || ^5.0 || ^6.0",
         "symfony/http-foundation": "^4.4.0 || ^5.0 || ^6.0",
-        "symfony/http-kernel": "^4.4.0 || ^5.0 || ^6.0"
+        "symfony/http-kernel": "^4.4.0 || ^5.0 || ^6.0",
+        "symfony/var-dumper": "^4.4.0 || ^5.0 || ^6.0",
     },
     "require-dev": {
         "php-http/guzzle7-adapter": "^0.1.1",
@@ -74,5 +75,10 @@
         "classmap": [
             "tests/Functional/Fixtures/app/AppKernel.php"
         ]
+    },
+    "config": {
+        "allow-plugins": {
+            "php-http/discovery": false
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/framework-bundle": "^4.4.0 || ^5.0 || ^6.0",
         "symfony/http-foundation": "^4.4.0 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^4.4.0 || ^5.0 || ^6.0",
-        "symfony/var-dumper": "^7.0"
+        "symfony/var-dumper": "^4.4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "php-http/guzzle7-adapter": "^0.1.1",

--- a/composer.json
+++ b/composer.json
@@ -25,8 +25,7 @@
         "friendsofsymfony/http-cache": "^2.15",
         "symfony/framework-bundle": "^4.4.0 || ^5.0 || ^6.0",
         "symfony/http-foundation": "^4.4.0 || ^5.0 || ^6.0",
-        "symfony/http-kernel": "^4.4.0 || ^5.0 || ^6.0",
-        "symfony/var-dumper": "^4.4.0 || ^5.0 || ^6.0"
+        "symfony/http-kernel": "^4.4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "php-http/guzzle7-adapter": "^0.1.1",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/framework-bundle": "^4.4.0 || ^5.0 || ^6.0",
         "symfony/http-foundation": "^4.4.0 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^4.4.0 || ^5.0 || ^6.0",
-        "symfony/var-dumper": "^4.4.0 || ^5.0 || ^6.0",
+        "symfony/var-dumper": "^4.4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "php-http/guzzle7-adapter": "^0.1.1",

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "symfony/framework-bundle": "^4.4.0 || ^5.0 || ^6.0",
         "symfony/http-foundation": "^4.4.0 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^4.4.0 || ^5.0 || ^6.0",
-        "symfony/var-dumper": "^4.4.0 || ^5.0 || ^6.0"
+        "symfony/var-dumper": "^7.0"
     },
     "require-dev": {
         "php-http/guzzle7-adapter": "^0.1.1",

--- a/composer.json
+++ b/composer.json
@@ -75,10 +75,5 @@
         "classmap": [
             "tests/Functional/Fixtures/app/AppKernel.php"
         ]
-    },
-    "config": {
-        "allow-plugins": {
-            "php-http/discovery": false
-        }
     }
 }

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -100,7 +100,7 @@ class CacheManager extends CacheInvalidator
      * Send all pending invalidation requests.
      *
      * @return int the number of cache invalidations performed per caching server
-     * 
+     *
      * @throws \FOS\HttpCache\Exception\ExceptionCollection
      */
     public function flush()

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -101,6 +101,7 @@ class CacheManager extends CacheInvalidator
         if (!$this->cache instanceof LazyObjectInterface || $this->cache->isLazyObjectInitialized()) {
             return parent::flush();
         }
+        
         return 0;
     }
 }

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -98,8 +98,7 @@ class CacheManager extends CacheInvalidator
 
     public function flush()
     {
-        if(!$this->cache instanceof LazyObjectInterface || $this->cache->isLazyObjectInitialized())
-        {
+        if (!$this->cache instanceof LazyObjectInterface || $this->cache->isLazyObjectInitialized()) {
             return parent::flush();
         }
         return 0;

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -96,6 +96,13 @@ class CacheManager extends CacheInvalidator
         return $this;
     }
 
+    /**
+     * Send all pending invalidation requests.
+     *
+     * @return int the number of cache invalidations performed per caching server
+     * 
+     * @throws \FOS\HttpCache\Exception\ExceptionCollection
+     */
     public function flush()
     {
         if (!$this->cache instanceof LazyObjectInterface || $this->cache->isLazyObjectInitialized()) {

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -14,6 +14,7 @@ namespace FOS\HttpCacheBundle;
 use FOS\HttpCache\CacheInvalidator;
 use FOS\HttpCache\ProxyClient\ProxyClient;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 
 /**
  * The CacheManager is a CacheInvalidator but adds symfony Route support and
@@ -23,6 +24,11 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  */
 class CacheManager extends CacheInvalidator
 {
+    /**
+     * @var ProxyClient
+     */
+    private $cache;
+
     /**
      * @var UrlGeneratorInterface
      */
@@ -44,6 +50,7 @@ class CacheManager extends CacheInvalidator
     public function __construct(ProxyClient $cache, UrlGeneratorInterface $urlGenerator)
     {
         parent::__construct($cache);
+        $this->cache = $cache;
         $this->urlGenerator = $urlGenerator;
     }
 
@@ -87,5 +94,14 @@ class CacheManager extends CacheInvalidator
         $this->refreshPath($this->urlGenerator->generate($route, $parameters, $this->generateUrlType), $headers);
 
         return $this;
+    }
+
+    public function flush()
+    {
+        if(!$this->cache instanceof LazyObjectInterface || $this->cache->isLazyObjectInitialized())
+        {
+            return parent::flush();
+        }
+        return 0;
     }
 }

--- a/src/CacheManager.php
+++ b/src/CacheManager.php
@@ -101,7 +101,7 @@ class CacheManager extends CacheInvalidator
         if (!$this->cache instanceof LazyObjectInterface || $this->cache->isLazyObjectInitialized()) {
             return parent::flush();
         }
-        
+
         return 0;
     }
 }

--- a/src/Resources/config/cloudflare.xml
+++ b/src/Resources/config/cloudflare.xml
@@ -7,7 +7,8 @@
     <services>
         <service id="fos_http_cache.proxy_client.cloudflare"
                  class="FOS\HttpCache\ProxyClient\Cloudflare"
-                 public="true">
+                 public="true"
+                 lazy="true">
             <argument type="service" id="fos_http_cache.proxy_client.cloudflare.http_dispatcher"/>
             <argument>%fos_http_cache.proxy_client.cloudflare.options%</argument>
         </service>

--- a/src/Resources/config/fastly.xml
+++ b/src/Resources/config/fastly.xml
@@ -7,7 +7,8 @@
     <services>
         <service id="fos_http_cache.proxy_client.fastly"
                  class="FOS\HttpCache\ProxyClient\Fastly"
-                 public="false">
+                 public="false"
+                 lazy="true">
             <argument type="service" id="fos_http_cache.proxy_client.fastly.http_dispatcher"/>
             <argument>%fos_http_cache.proxy_client.fastly.options%</argument>
         </service>

--- a/tests/Unit/CacheManagerTest.php
+++ b/tests/Unit/CacheManagerTest.php
@@ -11,6 +11,7 @@
 
 namespace FOS\HttpCacheBundle\Tests\Unit;
 
+use FOS\HttpCache\ProxyClient\HttpProxyClient;
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\ProxyClient;
@@ -18,6 +19,7 @@ use FOS\HttpCacheBundle\CacheManager;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 
 class CacheManagerTest extends TestCase
 {
@@ -83,5 +85,42 @@ class CacheManagerTest extends TestCase
             ->refreshRoute('route_with_params', ['id' => 123])
             ->refreshRoute('route_with_params', ['id' => 123], ['X-Foo' => 'bar'])
         ;
+    }
+
+    public function testSkipFlushOnEmptyInvalidationsAndLazyLoaded() {
+        $proxyClient = \Mockery::mock(HttpProxyClient::class, LazyObjectInterface::class)
+            ->shouldNotReceive('flush')
+            ->shouldReceive('isLazyObjectInitialized')->andReturn(false)
+            ->getMock();
+
+        $router = \Mockery::mock(UrlGeneratorInterface::class)->getMock();
+
+        $cacheInvalidator = new CacheManager($proxyClient, $router);
+        $this->assertEquals(0, $cacheInvalidator->flush());
+    }
+
+    public function testFlushOnNotLazyLoaded() {
+        $proxyClient = \Mockery::mock(HttpProxyClient::class)
+            ->shouldReceive('flush')->andReturn(0)
+            ->shouldNotReceive('isLazyObjectInitialized')
+            ->getMock();
+
+        $router = \Mockery::mock(UrlGeneratorInterface::class)->getMock();
+
+        $cacheInvalidator = new CacheManager($proxyClient, $router);
+        $this->assertEquals(0, $cacheInvalidator->flush());
+    }
+
+    public function testFlushOnLazyLoaded() {
+        $proxyClient = \Mockery::mock(HttpProxyClient::class, LazyObjectInterface::class, PurgeCapable::class);
+        $proxyClient->shouldReceive('flush')->andReturn(1);
+        $proxyClient->shouldReceive('purge');
+        $proxyClient->shouldReceive('isLazyObjectInitialized')->andReturn(true);
+
+        $router = \Mockery::mock(UrlGeneratorInterface::class)->getMock();
+
+        $cacheInvalidator = new CacheManager($proxyClient, $router);
+        $cacheInvalidator->invalidatePath('/foo');
+        $this->assertEquals(1, $cacheInvalidator->flush());
     }
 }

--- a/tests/Unit/CacheManagerTest.php
+++ b/tests/Unit/CacheManagerTest.php
@@ -93,7 +93,7 @@ class CacheManagerTest extends TestCase
             ->shouldReceive('isLazyObjectInitialized')->andReturn(false)
             ->getMock();
 
-        $router = \Mockery::mock(UrlGeneratorInterface::class)->getMock();
+        $router = \Mockery::mock(UrlGeneratorInterface::class);
 
         $cacheInvalidator = new CacheManager($proxyClient, $router);
         $this->assertEquals(0, $cacheInvalidator->flush());
@@ -105,7 +105,7 @@ class CacheManagerTest extends TestCase
             ->shouldNotReceive('isLazyObjectInitialized')
             ->getMock();
 
-        $router = \Mockery::mock(UrlGeneratorInterface::class)->getMock();
+        $router = \Mockery::mock(UrlGeneratorInterface::class);
 
         $cacheInvalidator = new CacheManager($proxyClient, $router);
         $this->assertEquals(0, $cacheInvalidator->flush());
@@ -117,7 +117,7 @@ class CacheManagerTest extends TestCase
         $proxyClient->shouldReceive('purge');
         $proxyClient->shouldReceive('isLazyObjectInitialized')->andReturn(true);
 
-        $router = \Mockery::mock(UrlGeneratorInterface::class)->getMock();
+        $router = \Mockery::mock(UrlGeneratorInterface::class);
 
         $cacheInvalidator = new CacheManager($proxyClient, $router);
         $cacheInvalidator->invalidatePath('/foo');

--- a/tests/Unit/CacheManagerTest.php
+++ b/tests/Unit/CacheManagerTest.php
@@ -87,7 +87,8 @@ class CacheManagerTest extends TestCase
         ;
     }
 
-    public function testSkipFlushOnEmptyInvalidationsAndLazyLoaded() {
+    public function testSkipFlushOnEmptyInvalidationsAndLazyLoaded()
+    {
         $proxyClient = \Mockery::mock(HttpProxyClient::class, LazyObjectInterface::class)
             ->shouldNotReceive('flush')
             ->shouldReceive('isLazyObjectInitialized')->andReturn(false)
@@ -99,7 +100,8 @@ class CacheManagerTest extends TestCase
         $this->assertEquals(0, $cacheInvalidator->flush());
     }
 
-    public function testFlushOnNotLazyLoaded() {
+    public function testFlushOnNotLazyLoaded()
+    {
         $proxyClient = \Mockery::mock(HttpProxyClient::class)
             ->shouldReceive('flush')->andReturn(0)
             ->shouldNotReceive('isLazyObjectInitialized')
@@ -111,7 +113,8 @@ class CacheManagerTest extends TestCase
         $this->assertEquals(0, $cacheInvalidator->flush());
     }
 
-    public function testFlushOnLazyLoaded() {
+    public function testFlushOnLazyLoaded()
+    {
         $proxyClient = \Mockery::mock(HttpProxyClient::class, LazyObjectInterface::class, PurgeCapable::class);
         $proxyClient->shouldReceive('flush')->andReturn(1);
         $proxyClient->shouldReceive('purge');


### PR DESCRIPTION
If one wants to use secrets as parameters for fastly or cloudflare, the compiling of the container will fail.
After compiling the container the termination event will cause this error cause it's not necessary to have the decrypt key available when compiling the container and the service can't be initialized.

This fix creates the services as lazy services which will not make the options necessary on compile time of the container.