### PR TITLE
Make fastly and cloudflare clients lazy loaded to support symfony secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+3.x
+===
+
+* Make `fastly` and `cloudflare` clients lazy loaded to support Symfony secrets that are only available at runtime, but
+  not yet when the container is built.
+
 2.x
 ===
 

--- a/src/Resources/config/cloudflare.xml
+++ b/src/Resources/config/cloudflare.xml
@@ -7,7 +7,8 @@
     <services>
         <service id="fos_http_cache.proxy_client.cloudflare"
                  class="FOS\HttpCache\ProxyClient\Cloudflare"
-                 public="true">
+                 public="true"
+                 lazy="true">
             <argument type="service" id="fos_http_cache.proxy_client.cloudflare.http_dispatcher"/>
             <argument>%fos_http_cache.proxy_client.cloudflare.options%</argument>
         </service>

--- a/src/Resources/config/fastly.xml
+++ b/src/Resources/config/fastly.xml
@@ -7,7 +7,8 @@
     <services>
         <service id="fos_http_cache.proxy_client.fastly"
                  class="FOS\HttpCache\ProxyClient\Fastly"
-                 public="false">
+                 public="false"
+                 lazy="true">
             <argument type="service" id="fos_http_cache.proxy_client.fastly.http_dispatcher"/>
             <argument>%fos_http_cache.proxy_client.fastly.options%</argument>
         </service>

--- a/tests/Unit/CacheManagerTest.php
+++ b/tests/Unit/CacheManagerTest.php
@@ -11,6 +11,7 @@
 
 namespace FOS\HttpCacheBundle\Tests\Unit;
 
+use FOS\HttpCache\ProxyClient\HttpProxyClient;
 use FOS\HttpCache\ProxyClient\Invalidation\PurgeCapable;
 use FOS\HttpCache\ProxyClient\Invalidation\RefreshCapable;
 use FOS\HttpCache\ProxyClient\ProxyClient;
@@ -18,6 +19,7 @@ use FOS\HttpCacheBundle\CacheManager;
 use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Symfony\Component\VarExporter\LazyObjectInterface;
 
 class CacheManagerTest extends TestCase
 {
@@ -83,5 +85,45 @@ class CacheManagerTest extends TestCase
             ->refreshRoute('route_with_params', ['id' => 123])
             ->refreshRoute('route_with_params', ['id' => 123], ['X-Foo' => 'bar'])
         ;
+    }
+
+    public function testSkipFlushOnEmptyInvalidationsAndLazyLoaded()
+    {
+        $proxyClient = \Mockery::mock(HttpProxyClient::class, LazyObjectInterface::class)
+            ->shouldNotReceive('flush')
+            ->shouldReceive('isLazyObjectInitialized')->andReturn(false)
+            ->getMock();
+
+        $router = \Mockery::mock(UrlGeneratorInterface::class);
+
+        $cacheInvalidator = new CacheManager($proxyClient, $router);
+        $this->assertEquals(0, $cacheInvalidator->flush());
+    }
+
+    public function testFlushOnNotLazyLoaded()
+    {
+        $proxyClient = \Mockery::mock(HttpProxyClient::class)
+            ->shouldReceive('flush')->andReturn(0)
+            ->shouldNotReceive('isLazyObjectInitialized')
+            ->getMock();
+
+        $router = \Mockery::mock(UrlGeneratorInterface::class);
+
+        $cacheInvalidator = new CacheManager($proxyClient, $router);
+        $this->assertEquals(0, $cacheInvalidator->flush());
+    }
+
+    public function testFlushOnLazyLoaded()
+    {
+        $proxyClient = \Mockery::mock(HttpProxyClient::class, LazyObjectInterface::class, PurgeCapable::class);
+        $proxyClient->shouldReceive('flush')->andReturn(1);
+        $proxyClient->shouldReceive('purge');
+        $proxyClient->shouldReceive('isLazyObjectInitialized')->andReturn(true);
+
+        $router = \Mockery::mock(UrlGeneratorInterface::class);
+
+        $cacheInvalidator = new CacheManager($proxyClient, $router);
+        $cacheInvalidator->invalidatePath('/foo');
+        $this->assertEquals(1, $cacheInvalidator->flush());
     }
 }


### PR DESCRIPTION
author DemigodCode <info@bl-websolutions.de> 1702912036 +0100 
committer David Buchmann <david.buchmann@liip.ch> 1702989567 +0100

If one wants to use secrets as parameters for fastly or cloudflare, the compiling of the container will fail. After compiling the container the termination event will cause this error cause it's not necessary to have the decrypt key available when compiling the container and the service can't be initialized.

This fix creates the services as lazy services which will not make the options necessary on compile time of the container.