### PR TITLE
Allow usage of friendsofsymfony/http-cache ^3.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     ],
     "require": {
         "php": "^8.1",
-        "friendsofsymfony/http-cache": "^2.15 || 3.x-dev",
+        "friendsofsymfony/http-cache": "^2.15 || ^3.0",
         "symfony/framework-bundle": "^6.4 || ^7.0",
         "symfony/http-foundation": "^6.4 || ^7.0",
         "symfony/http-kernel": "^6.4 || ^7.0"
@@ -77,5 +77,6 @@
         "allow-plugins": {
             "php-http/discovery": true
         }
-    }
+    },
+    "minimum-stability": "dev"
 }


### PR DESCRIPTION
I think composer does not interpret `3.x-dev` as `3.0-dev`.

![Bildschirmfoto 2024-04-08 um 14 36 38](https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/assets/1698337/242c53ac-1a20-4557-9691-40e7331d7f7d)

I recommend to use `composer config minimum-stability dev` ([has no effects to projects](https://getcomposer.org/doc/04-schema.md#minimum-stability)) or we go with `^2.15 || ^3.0 || ^3.0@dev`