### PR TITLE
fix: static typing and final classes

### DIFF
--- a/src/DependencyInjection/Compiler/HashGeneratorPass.php
+++ b/src/DependencyInjection/Compiler/HashGeneratorPass.php
@@ -19,9 +19,9 @@ use Symfony\Component\DependencyInjection\Reference;
 /**
  * Add tagged provider to the hash generator for user context.
  */
-class HashGeneratorPass implements CompilerPassInterface
+final class HashGeneratorPass implements CompilerPassInterface
 {
-    const TAG_NAME = 'fos_http_cache.user_context_provider';
+    public const TAG_NAME = 'fos_http_cache.user_context_provider';
 
     /**
      * {@inheritdoc}

--- a/src/DependencyInjection/Compiler/LoggerPass.php
+++ b/src/DependencyInjection/Compiler/LoggerPass.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 /**
  * Announce the log listener to the symfony event system.
  */
-class LoggerPass implements CompilerPassInterface
+final class LoggerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/DependencyInjection/Compiler/SessionListenerPass.php
+++ b/src/DependencyInjection/Compiler/SessionListenerPass.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
  * AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER from being leaked to
  * the client.
  */
-class SessionListenerPass implements CompilerPassInterface
+final class SessionListenerPass implements CompilerPassInterface
 {
     /**
      * {@inheritdoc}

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -18,7 +18,6 @@ use FOS\HttpCache\TagHeaderFormatter\TagHeaderFormatter;
 use JeanBeru\HttpCacheCloudFront\Proxy\CloudFront;
 use Symfony\Component\Config\Definition\Builder\ArrayNodeDefinition;
 use Symfony\Component\Config\Definition\Builder\NodeBuilder;
-use Symfony\Component\Config\Definition\Builder\NodeDefinition;
 use Symfony\Component\Config\Definition\Builder\TreeBuilder;
 use Symfony\Component\Config\Definition\ConfigurationInterface;
 use Symfony\Component\Config\Definition\Exception\InvalidConfigurationException;
@@ -55,13 +54,7 @@ final class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder(): TreeBuilder
     {
         $treeBuilder = new TreeBuilder('fos_http_cache');
-
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $rootNode = $treeBuilder->root('fos_http_cache');
-        } else {
-            $rootNode = $treeBuilder->getRootNode();
-        }
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->validate()
@@ -610,19 +603,11 @@ final class Configuration implements ConfigurationInterface
 
     /**
      * Get the configuration node for a HTTP dispatcher in a proxy client.
-     *
-     * @return NodeDefinition
      */
     private function getHttpDispatcherNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('http');
-
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->root('http');
-        } else {
-            $node = $treeBuilder->getRootNode();
-        }
+        $node = $treeBuilder->getRootNode();
 
         $node
             ->fixXmlConfig('server')
@@ -653,13 +638,7 @@ final class Configuration implements ConfigurationInterface
     private function getCloudflareHttpDispatcherNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('http');
-
-        // Keep compatibility with symfony/config < 4.2
-        if (!method_exists($treeBuilder, 'getRootNode')) {
-            $node = $treeBuilder->root('http');
-        } else {
-            $node = $treeBuilder->getRootNode();
-        }
+        $node = $treeBuilder->getRootNode();
 
         $node
             ->addDefaultsIfNotSet()
@@ -683,7 +662,6 @@ final class Configuration implements ConfigurationInterface
     private function getFastlyHttpDispatcherNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('http');
-
         $node = $treeBuilder->getRootNode();
 
         $node

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -34,7 +34,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  * @author David de Boer <david@driebit.nl>
  * @author David Buchmann <mail@davidbu.ch>
  */
-class Configuration implements ConfigurationInterface
+final class Configuration implements ConfigurationInterface
 {
     /**
      * @var bool
@@ -240,7 +240,7 @@ class Configuration implements ConfigurationInterface
             && array_key_exists('fastly', $v['proxy_client']);
     }
 
-    private function addCacheableResponseSection(ArrayNodeDefinition $rootNode)
+    private function addCacheableResponseSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->children()
@@ -278,7 +278,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Cache header control main section.
      */
-    private function addCacheControlSection(ArrayNodeDefinition $rootNode)
+    private function addCacheControlSection(ArrayNodeDefinition $rootNode): void
     {
         $rules = $rootNode
             ->children()
@@ -366,7 +366,7 @@ class Configuration implements ConfigurationInterface
      *
      * @param bool $matchResponse whether to also add fields to match response
      */
-    private function addMatch(NodeBuilder $rules, $matchResponse = false)
+    private function addMatch(NodeBuilder $rules, $matchResponse = false): void
     {
         $match = $rules
             ->arrayNode('match')
@@ -613,7 +613,7 @@ class Configuration implements ConfigurationInterface
      *
      * @return NodeDefinition
      */
-    private function getHttpDispatcherNode()
+    private function getHttpDispatcherNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('http');
 
@@ -650,7 +650,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    private function getCloudflareHttpDispatcherNode()
+    private function getCloudflareHttpDispatcherNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('http');
 
@@ -680,7 +680,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    private function getFastlyHttpDispatcherNode()
+    private function getFastlyHttpDispatcherNode(): ArrayNodeDefinition
     {
         $treeBuilder = new TreeBuilder('http');
 
@@ -709,7 +709,7 @@ class Configuration implements ConfigurationInterface
         return $node;
     }
 
-    private function addTestSection(ArrayNodeDefinition $rootNode)
+    private function addTestSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->children()
@@ -752,7 +752,7 @@ class Configuration implements ConfigurationInterface
     /**
      * Cache manager main section.
      */
-    private function addCacheManagerSection(ArrayNodeDefinition $rootNode)
+    private function addCacheManagerSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->children()
@@ -792,7 +792,7 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
-    private function addTagSection(ArrayNodeDefinition $rootNode)
+    private function addTagSection(ArrayNodeDefinition $rootNode): void
     {
         $rules = $rootNode
             ->children()
@@ -848,7 +848,7 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
-    private function addInvalidationSection(ArrayNodeDefinition $rootNode)
+    private function addInvalidationSection(ArrayNodeDefinition $rootNode): void
     {
         $rules = $rootNode
             ->children()
@@ -889,7 +889,7 @@ class Configuration implements ConfigurationInterface
     /**
      * User context main section.
      */
-    private function addUserContextListenerSection(ArrayNodeDefinition $rootNode)
+    private function addUserContextListenerSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->children()
@@ -958,7 +958,7 @@ class Configuration implements ConfigurationInterface
         ;
     }
 
-    private function addFlashMessageSection(ArrayNodeDefinition $rootNode)
+    private function addFlashMessageSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->children()
@@ -988,7 +988,7 @@ class Configuration implements ConfigurationInterface
             ->end();
     }
 
-    private function addDebugSection(ArrayNodeDefinition $rootNode)
+    private function addDebugSection(ArrayNodeDefinition $rootNode): void
     {
         $rootNode
             ->children()

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -31,7 +31,7 @@ use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 
-class FOSHttpCacheExtension extends Extension
+final class FOSHttpCacheExtension extends Extension
 {
     public function getConfiguration(array $config, ContainerBuilder $container): ConfigurationInterface
     {
@@ -579,7 +579,7 @@ class FOSHttpCacheExtension extends Extension
         );
     }
 
-    private function loadVarnishProxyServer(ContainerBuilder $container, XmlFileLoader $loader, $config): void
+    private function loadVarnishProxyServer(ContainerBuilder $container, XmlFileLoader $loader, array $config): void
     {
         $loader->load('varnish_proxy.xml');
         foreach ($config as $key => $value) {
@@ -590,7 +590,7 @@ class FOSHttpCacheExtension extends Extension
         }
     }
 
-    private function loadNginxProxyServer(ContainerBuilder $container, XmlFileLoader $loader, $config): void
+    private function loadNginxProxyServer(ContainerBuilder $container, XmlFileLoader $loader, array $config): void
     {
         $loader->load('nginx_proxy.xml');
         foreach ($config as $key => $value) {
@@ -627,7 +627,7 @@ class FOSHttpCacheExtension extends Extension
         }
     }
 
-    private function validateUrl($url, $msg): void
+    private function validateUrl(string $url, string $msg): void
     {
         $prefixed = $this->prefixSchema($url);
 
@@ -636,7 +636,7 @@ class FOSHttpCacheExtension extends Extension
         }
     }
 
-    private function prefixSchema($url)
+    private function prefixSchema(string $url): string
     {
         if (!str_contains($url, '://')) {
             $url = sprintf('%s://%s', 'http', $url);
@@ -645,7 +645,7 @@ class FOSHttpCacheExtension extends Extension
         return $url;
     }
 
-    private function getDefaultProxyClient(array $config)
+    private function getDefaultProxyClient(array $config): string
     {
         if (isset($config['default'])) {
             return $config['default'];

--- a/src/EventListener/AbstractRuleListener.php
+++ b/src/EventListener/AbstractRuleListener.php
@@ -31,7 +31,7 @@ abstract class AbstractRuleListener
     public function addRule(
         RequestMatcherInterface $requestMatcher,
         array $settings = []
-    ) {
+    ): void {
         $this->rulesMap[] = [$requestMatcher, $settings];
     }
 
@@ -40,7 +40,7 @@ abstract class AbstractRuleListener
      *
      * @return array|false Settings to apply or false if no rule matched
      */
-    protected function matchRule(Request $request)
+    protected function matchRule(Request $request): array|false
     {
         foreach ($this->rulesMap as $elements) {
             if ($elements[0]->matches($request)) {

--- a/src/EventListener/AttributesListener.php
+++ b/src/EventListener/AttributesListener.php
@@ -15,7 +15,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * @author Yoann Chocteau <yoann@kezaweb.fr>
  */
-class AttributesListener implements EventSubscriberInterface
+final class AttributesListener implements EventSubscriberInterface
 {
     public function __construct(
         private ControllerResolverInterface $controllerResolver

--- a/src/EventListener/CacheControlListener.php
+++ b/src/EventListener/CacheControlListener.php
@@ -26,7 +26,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  * @author Lea Haensenberger <lea.haensenberger@gmail.com>
  * @author David Buchmann <mail@davidbu.ch>
  */
-class CacheControlListener implements EventSubscriberInterface
+final class CacheControlListener implements EventSubscriberInterface
 {
     /**
      * Whether to skip this response and not set any cache headers.
@@ -52,7 +52,7 @@ class CacheControlListener implements EventSubscriberInterface
      * If not empty, add a debug header with that name to all responses,
      * telling the cache proxy to add debug output.
      *
-     * @var string|bool Name of the header or false to add no header
+     * @var string|false Name of the header or false to add no header
      */
     private string|false $debugHeader;
 
@@ -96,7 +96,7 @@ class CacheControlListener implements EventSubscriberInterface
         $response = $event->getResponse();
 
         if ($this->debugHeader) {
-            $response->headers->set($this->debugHeader, 1, false);
+            $response->headers->set($this->debugHeader, '1', false);
         }
 
         // do not change cache directives on non-cacheable requests.
@@ -125,7 +125,7 @@ class CacheControlListener implements EventSubscriberInterface
             && null !== $options['reverse_proxy_ttl']
             && !$response->headers->has('X-Reverse-Proxy-TTL')
         ) {
-            $response->headers->set('X-Reverse-Proxy-TTL', (int) $options['reverse_proxy_ttl'], false);
+            $response->headers->set('X-Reverse-Proxy-TTL', $options['reverse_proxy_ttl'], false);
         }
 
         if (!empty($options['vary'])) {

--- a/src/EventListener/InvalidationListener.php
+++ b/src/EventListener/InvalidationListener.php
@@ -33,7 +33,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
  *
  * @author David de Boer <david@driebit.nl>
  */
-class InvalidationListener extends AbstractRuleListener implements EventSubscriberInterface
+final class InvalidationListener extends AbstractRuleListener implements EventSubscriberInterface
 {
     private CacheManager $cacheManager;
     private UrlGeneratorInterface $urlGenerator;
@@ -136,7 +136,7 @@ class InvalidationListener extends AbstractRuleListener implements EventSubscrib
         }
 
         // Check configured invalidators
-        if (!$invalidatorConfigs = $this->matchRule($request, $response)) {
+        if (!$invalidatorConfigs = $this->matchRule($request)) {
             return;
         }
 

--- a/src/EventListener/SwitchUserListener.php
+++ b/src/EventListener/SwitchUserListener.php
@@ -16,7 +16,7 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\Security\Http\Event\SwitchUserEvent;
 use Symfony\Component\Security\Http\SecurityEvents;
 
-class SwitchUserListener implements EventSubscriberInterface
+final class SwitchUserListener implements EventSubscriberInterface
 {
     private UserContextInvalidator $invalidator;
 

--- a/src/EventListener/TagListener.php
+++ b/src/EventListener/TagListener.php
@@ -27,7 +27,7 @@ use Symfony\Component\HttpKernel\KernelEvents;
  *
  * @author David de Boer <david@driebit.nl>
  */
-class TagListener extends AbstractRuleListener implements EventSubscriberInterface
+final class TagListener extends AbstractRuleListener implements EventSubscriberInterface
 {
     private CacheManager $cacheManager;
     private SymfonyResponseTagger $symfonyResponseTagger;
@@ -108,7 +108,7 @@ class TagListener extends AbstractRuleListener implements EventSubscriberInterfa
      * Get the tags from the attributes on the controller that was used in the
      * request.
      *
-     * @return array List of tags affected by the request
+     * @return string[] List of tags affected by the request
      */
     private function getAttributeTags(Request $request): array
     {

--- a/src/EventListener/UserContextListener.php
+++ b/src/EventListener/UserContextListener.php
@@ -34,7 +34,7 @@ use Symfony\Component\OptionsResolver\OptionsResolver;
  * @author Stefan Paschke <stefan.paschke@gmail.com>
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
-class UserContextListener implements EventSubscriberInterface
+final class UserContextListener implements EventSubscriberInterface
 {
     private RequestMatcherInterface $requestMatcher;
     private HashGenerator $hashGenerator;
@@ -136,7 +136,7 @@ class UserContextListener implements EventSubscriberInterface
             $response->setPublic();
             if ($this->hasSessionListener) {
                 // header to avoid Symfony SessionListener overwriting the response to private
-                $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 1);
+                $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '1');
             }
         } else {
             $response->setClientTtl(0);
@@ -201,7 +201,7 @@ class UserContextListener implements EventSubscriberInterface
             // user hash header was in vary or just added here by "add_vary_on_hash"
             if ($this->hasSessionListener && in_array($this->options['user_hash_header'], $vary, true)) {
                 // header to avoid Symfony SessionListener overwriting the response to private
-                $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, 1);
+                $response->headers->set(AbstractSessionListener::NO_AUTO_CACHE_CONTROL_HEADER, '1');
             }
         } elseif ($this->options['add_vary_on_hash']) {
             /*

--- a/src/Exception/InvalidTagException.php
+++ b/src/Exception/InvalidTagException.php
@@ -13,7 +13,7 @@ namespace FOS\HttpCacheBundle\Exception;
 
 class InvalidTagException extends \InvalidArgumentException
 {
-    public function __construct($tag, $char)
+    public function __construct(string $tag, string $char)
     {
         parent::__construct(sprintf('Tag %s is invalid because it contains %s', $tag, $char));
     }

--- a/src/FOSHttpCacheBundle.php
+++ b/src/FOSHttpCacheBundle.php
@@ -18,7 +18,7 @@ use FOS\HttpCacheBundle\DependencyInjection\Compiler\SessionListenerPass;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 
-class FOSHttpCacheBundle extends Bundle
+final class FOSHttpCacheBundle extends Bundle
 {
     /**
      * {@inheritdoc}

--- a/src/Http/RequestMatcher/CacheableRequestMatcher.php
+++ b/src/Http/RequestMatcher/CacheableRequestMatcher.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 /**
  * @see https://tools.ietf.org/html/rfc7231#section-4.2.3
  */
-class CacheableRequestMatcher implements RequestMatcherInterface
+final class CacheableRequestMatcher implements RequestMatcherInterface
 {
     public function matches(Request $request): bool
     {

--- a/src/Http/RequestMatcher/QueryStringRequestMatcher.php
+++ b/src/Http/RequestMatcher/QueryStringRequestMatcher.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 /**
  * Additional request matcher for query string matching.
  */
-class QueryStringRequestMatcher implements RequestMatcherInterface
+final class QueryStringRequestMatcher implements RequestMatcherInterface
 {
     /**
      * @var string Regular expression to match the query string part of the request url

--- a/src/Http/RequestMatcher/UnsafeRequestMatcher.php
+++ b/src/Http/RequestMatcher/UnsafeRequestMatcher.php
@@ -14,7 +14,7 @@ namespace FOS\HttpCacheBundle\Http\RequestMatcher;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
-class UnsafeRequestMatcher implements RequestMatcherInterface
+final class UnsafeRequestMatcher implements RequestMatcherInterface
 {
     public function matches(Request $request): bool
     {

--- a/src/Http/ResponseMatcher/CacheableResponseMatcher.php
+++ b/src/Http/ResponseMatcher/CacheableResponseMatcher.php
@@ -18,15 +18,21 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @see https://tools.ietf.org/html/rfc7231#section-6.1
  */
-class CacheableResponseMatcher implements ResponseMatcherInterface
+final class CacheableResponseMatcher implements ResponseMatcherInterface
 {
-    private $cacheableStatusCodes = [
+    /**
+     * @var int[]
+     */
+    private array $cacheableStatusCodes = [
         200, 203, 204, 206,
         300, 301,
         404, 405, 410, 414,
         501,
     ];
 
+    /**
+     * @param int[] $additionalStatusCodes
+     */
     public function __construct(array $additionalStatusCodes = [])
     {
         $this->cacheableStatusCodes = array_merge(

--- a/src/Http/ResponseMatcher/ExpressionResponseMatcher.php
+++ b/src/Http/ResponseMatcher/ExpressionResponseMatcher.php
@@ -14,7 +14,7 @@ namespace FOS\HttpCacheBundle\Http\ResponseMatcher;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpFoundation\Response;
 
-class ExpressionResponseMatcher implements ResponseMatcherInterface
+final class ExpressionResponseMatcher implements ResponseMatcherInterface
 {
     private ?ExpressionLanguage $expressionLanguage;
     private string $expression;

--- a/src/Http/ResponseMatcher/NonErrorResponseMatcher.php
+++ b/src/Http/ResponseMatcher/NonErrorResponseMatcher.php
@@ -19,7 +19,7 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @see https://tools.ietf.org/html/rfc7234#section-4.4
  */
-class NonErrorResponseMatcher implements ResponseMatcherInterface
+final class NonErrorResponseMatcher implements ResponseMatcherInterface
 {
     public function matches(Response $response)
     {

--- a/src/Http/RuleMatcher.php
+++ b/src/Http/RuleMatcher.php
@@ -23,25 +23,19 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * @author David Buchmann <mail@davidbu.ch>
  */
-class RuleMatcher implements RuleMatcherInterface
+final class RuleMatcher implements RuleMatcherInterface
 {
-    /**
-     * @var RequestMatcherInterface
-     */
-    private $requestMatcher;
+    private ?RequestMatcherInterface $requestMatcher;
 
-    /**
-     * @var ResponseMatcherInterface
-     */
-    private $responseMatcher;
+    private ?ResponseMatcherInterface $responseMatcher;
 
     /**
      * @param RequestMatcherInterface  $requestMatcher|null  Request matcher
      * @param ResponseMatcherInterface $responseMatcher|null Response matcher
      */
     public function __construct(
-        RequestMatcherInterface $requestMatcher = null,
-        ResponseMatcherInterface $responseMatcher = null
+        ?RequestMatcherInterface $requestMatcher = null,
+        ?ResponseMatcherInterface $responseMatcher = null
     ) {
         $this->requestMatcher = $requestMatcher;
         $this->responseMatcher = $responseMatcher;

--- a/src/Security/Http/Logout/ContextInvalidationLogoutHandler.php
+++ b/src/Security/Http/Logout/ContextInvalidationLogoutHandler.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
  * This handler is deprecated because it never did what it was supposed to do. The session is already invalidated by the SessionLogoutHandler
  * which is always the first logout handler executed
  */
-class ContextInvalidationLogoutHandler implements LogoutHandlerInterface
+final class ContextInvalidationLogoutHandler implements LogoutHandlerInterface
 {
     private $invalidator;
 

--- a/src/Security/Http/Logout/ContextInvalidationLogoutHandler.php
+++ b/src/Security/Http/Logout/ContextInvalidationLogoutHandler.php
@@ -24,7 +24,7 @@ use Symfony\Component\Security\Http\Logout\LogoutHandlerInterface;
  * This handler is deprecated because it never did what it was supposed to do. The session is already invalidated by the SessionLogoutHandler
  * which is always the first logout handler executed
  */
-final class ContextInvalidationLogoutHandler implements LogoutHandlerInterface
+class ContextInvalidationLogoutHandler implements LogoutHandlerInterface
 {
     private $invalidator;
 

--- a/src/Security/Http/Logout/ContextInvalidationSessionLogoutHandler.php
+++ b/src/Security/Http/Logout/ContextInvalidationSessionLogoutHandler.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Http\EventListener\SessionLogoutListener;
 
 final class ContextInvalidationSessionLogoutHandler extends SessionLogoutListener
 {
-    private $invalidator;
+    private UserContextInvalidator $invalidator;
 
     public function __construct(UserContextInvalidator $invalidator)
     {

--- a/src/Twig/CacheTagExtension.php
+++ b/src/Twig/CacheTagExtension.php
@@ -48,9 +48,9 @@ class CacheTagExtension extends AbstractExtension
      *
      * Calling this twig function adds nothing to the output.
      *
-     * @param string|array $tag
+     * @param string|string[] $tag
      */
-    public function addTag($tag)
+    public function addTag($tag): void
     {
         $this->responseTagger->addTags((array) $tag);
     }

--- a/src/UserContext/RequestMatcher.php
+++ b/src/UserContext/RequestMatcher.php
@@ -14,13 +14,13 @@ namespace FOS\HttpCacheBundle\UserContext;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestMatcherInterface;
 
-class RequestMatcher implements RequestMatcherInterface
+final class RequestMatcher implements RequestMatcherInterface
 {
-    private $method;
+    private ?string $method;
 
-    private $accept;
+    private ?string $accept;
 
-    public function __construct($accept = 'application/vnd.fos.user-context-hash', $method = null)
+    public function __construct(?string $accept = 'application/vnd.fos.user-context-hash', ?string $method = null)
     {
         $this->accept = $accept;
         $this->method = $method;

--- a/src/UserContext/RoleProvider.php
+++ b/src/UserContext/RoleProvider.php
@@ -20,7 +20,7 @@ use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInt
 /**
  * The RoleProvider adds roles to the UserContext for the hash generation.
  */
-class RoleProvider implements ContextProvider
+final class RoleProvider implements ContextProvider
 {
     /**
      * Create the role provider with a security context.

--- a/src/UserContextInvalidator.php
+++ b/src/UserContextInvalidator.php
@@ -15,7 +15,7 @@ use FOS\HttpCache\ProxyClient\Invalidation\TagCapable;
 
 class UserContextInvalidator
 {
-    const USER_CONTEXT_TAG_PREFIX = 'fos_http_cache_hashlookup-';
+    public const USER_CONTEXT_TAG_PREFIX = 'fos_http_cache_hashlookup-';
 
     /**
      * @var TagCapable
@@ -32,12 +32,12 @@ class UserContextInvalidator
      *
      * @param string $sessionId
      */
-    public function invalidateContext($sessionId)
+    public function invalidateContext($sessionId): void
     {
         $this->tagger->invalidateTags([static::buildTag($sessionId)]);
     }
 
-    public static function buildTag($hash)
+    public static function buildTag(string $hash): string
     {
         return static::USER_CONTEXT_TAG_PREFIX.$hash;
     }


### PR DESCRIPTION
Fixes #603

### Mark internal classes final
I sticked to the rules outlined by Ocramius in https://ocramius.github.io/blog/when-to-declare-classes-final/

### Static typing
Fixes most typing related errors from `phpstan analyze -l 6 src'
- excluding typing of items within arrays (https://phpstan.org/blog/solving-phpstan-no-value-type-specified-in-iterable-type)
- excluding non-typing related errors