### PR TITLE
fix: treat Twig as optional

### DIFF
--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -30,6 +30,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
 use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
+use Twig\TwigFunction;
 
 final class FOSHttpCacheExtension extends Extension
 {
@@ -531,6 +532,9 @@ final class FOSHttpCacheExtension extends Extension
         $container->setParameter('fos_http_cache.tag_handler.strict', $config['strict']);
 
         $loader->load('cache_tagging.xml');
+        if (class_exists(TwigFunction::class)) {
+            $loader->load('cache_tagging_twig.xml');
+        }
         if (class_exists(Application::class)) {
             $loader->load('cache_tagging_commands.xml');
         }

--- a/src/Resources/config/cache_tagging.xml
+++ b/src/Resources/config/cache_tagging.xml
@@ -21,11 +21,6 @@
 
         <service id="FOS\HttpCache\ResponseTagger" alias="fos_http_cache.http.symfony_response_tagger" public="true"/>
 
-        <service id="fos_http_cache.twig.tag_extension" class="FOS\HttpCacheBundle\Twig\CacheTagExtension">
-            <argument id="fos_http_cache.http.symfony_response_tagger" type="service"/>
-            <tag name="twig.extension"/>
-        </service>
-
         <service id="fos_http_cache.event_listener.tag" class="FOS\HttpCacheBundle\EventListener\TagListener">
             <argument type="service" id="fos_http_cache.cache_manager" />
             <argument type="service" id="fos_http_cache.http.symfony_response_tagger" />

--- a/src/Resources/config/cache_tagging_twig.xml
+++ b/src/Resources/config/cache_tagging_twig.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" ?>
+
+<container xmlns="http://symfony.com/schema/dic/services"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
+
+    <services>
+        <service id="fos_http_cache.twig.tag_extension" class="FOS\HttpCacheBundle\Twig\CacheTagExtension">
+            <argument id="fos_http_cache.http.symfony_response_tagger" type="service"/>
+            <tag name="twig.extension"/>
+        </service>
+    </services>
+</container>


### PR DESCRIPTION
Only load CacheTagExtension service in case Twig is available