### PR TITLE
feat: allow to configure header name for reverse_proxy_ttl specific value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ Changelog
 3.x
 ===
 
+3.1.0
+-----
+
+### Added
+
+* New Feature: allow configuring the TTL header name for the special `reverse_proxy_ttl` config value. #638
+
 3.0.2
 -----
 

--- a/Resources/doc/reference/configuration/headers.rst
+++ b/Resources/doc/reference/configuration/headers.rst
@@ -345,3 +345,26 @@ section:
                             s_maxage: 60
 
 This example adds the header ``X-Reverse-Proxy-TTL: 3600`` to your responses.
+
+``ttl_header``
+--------------
+
+**type**: ``string`` default `X-Reverse-Proxy-TTL`
+
+Change the name for the header for reverse proxy.
+
+.. code-block:: yaml
+
+    # app/config/config.yml
+    fos_http_cache:
+        cache_control:
+            ttl_header: X-My-Cache-Control
+            rules:
+                -
+                    headers:
+                        reverse_proxy_ttl: 3600
+                        cache_control:
+                            public: true
+                            s_maxage: 60
+
+This example adds the header ``X-My-Cache-Control: 3600`` to your responses.

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -277,6 +277,10 @@ final class Configuration implements ConfigurationInterface
                                 ->end()
                             ->end()
                         ->end()
+                        ->scalarNode('ttl_header')
+                            ->defaultValue('X-Reverse-Proxy-TTL')
+                            ->info('Specify the header name to use with the cache_control.reverse_proxy_ttl setting')
+                        ->end()
                         ->arrayNode('rules')
                             ->prototype('array')
                                 ->children();
@@ -330,7 +334,7 @@ final class Configuration implements ConfigurationInterface
                     ->end()
                     ->scalarNode('reverse_proxy_ttl')
                         ->defaultNull()
-                        ->info('Specify an X-Reverse-Proxy-TTL header with a time in seconds for a caching proxy under your control.')
+                        ->info('Specify a custom time to live in seconds for your caching proxy. This value is sent in the custom header configured in cache_control.ttl_header.')
                     ->end()
                     ->arrayNode('vary')
                         ->beforeNormalization()->ifString()->then(function ($v) {

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -48,7 +48,9 @@ final class FOSHttpCacheExtension extends Extension
 
         if ($config['debug']['enabled'] || (!empty($config['cache_control']))) {
             $debugHeader = $config['debug']['enabled'] ? $config['debug']['header'] : false;
+            $ttlHeader = $config['cache_control']['ttl_header'];
             $container->setParameter('fos_http_cache.debug_header', $debugHeader);
+            $container->setParameter('fos_http_cache.ttl_header', $ttlHeader);
             $loader->load('cache_control_listener.xml');
         }
 

--- a/src/EventListener/CacheControlListener.php
+++ b/src/EventListener/CacheControlListener.php
@@ -56,6 +56,7 @@ final class CacheControlListener implements EventSubscriberInterface
          * @var string|false Name of the header or false to add no header
          */
         private readonly string|false $debugHeader = false,
+        private readonly string $ttlHeader = 'X-Reverse-Proxy-TTL',
     ) {
     }
 
@@ -115,9 +116,9 @@ final class CacheControlListener implements EventSubscriberInterface
 
         if (array_key_exists('reverse_proxy_ttl', $options)
             && null !== $options['reverse_proxy_ttl']
-            && !$response->headers->has('X-Reverse-Proxy-TTL')
+            && !$response->headers->has($this->ttlHeader)
         ) {
-            $response->headers->set('X-Reverse-Proxy-TTL', $options['reverse_proxy_ttl'], false);
+            $response->headers->set($this->ttlHeader, $options['reverse_proxy_ttl'], false);
         }
 
         if (!empty($options['vary'])) {

--- a/src/Resources/config/cache_control_listener.xml
+++ b/src/Resources/config/cache_control_listener.xml
@@ -9,6 +9,7 @@
                  class="FOS\HttpCacheBundle\EventListener\CacheControlListener"
                  public="true">
             <argument>%fos_http_cache.debug_header%</argument>
+            <argument>%fos_http_cache.ttl_header%</argument>
             <tag name="kernel.event_subscriber" />
         </service>
         <service id="FOS\HttpCacheBundle\EventListener\CacheControlListener" alias="fos_http_cache.event_listener.cache_control" public="true"/>

--- a/tests/Resources/Fixtures/config/etag_true.php
+++ b/tests/Resources/Fixtures/config/etag_true.php
@@ -21,6 +21,7 @@ $container->loadFromExtension(
                     ],
                 ],
             ],
+            'ttl_header' => 'X-Reverse-Proxy-TTL',
         ],
     ]
 );

--- a/tests/Resources/Fixtures/config/etag_true.xml
+++ b/tests/Resources/Fixtures/config/etag_true.xml
@@ -9,6 +9,7 @@
                 <headers etag="true">
                 </headers>
             </rule>
+            <ttl-header>X-Reverse-Proxy-TTL</ttl-header>
         </cache-control>
     </config>
 

--- a/tests/Resources/Fixtures/config/etag_true.yml
+++ b/tests/Resources/Fixtures/config/etag_true.yml
@@ -6,3 +6,4 @@ fos_http_cache:
                     path: null
                 headers:
                     etag: true
+        ttl_header: X-Reverse-Proxy-TTL

--- a/tests/Resources/Fixtures/config/etag_weak.php
+++ b/tests/Resources/Fixtures/config/etag_weak.php
@@ -21,6 +21,7 @@ $container->loadFromExtension(
                     ],
                 ],
             ],
+            'ttl_header' => 'X-Reverse-Proxy-TTL',
         ],
     ]
 );

--- a/tests/Resources/Fixtures/config/etag_weak.xml
+++ b/tests/Resources/Fixtures/config/etag_weak.xml
@@ -9,6 +9,7 @@
                 <headers etag="weak">
                 </headers>
             </rule>
+            <ttl-header>X-Reverse-Proxy-TTL</ttl-header>
         </cache-control>
     </config>
 

--- a/tests/Resources/Fixtures/config/etag_weak.yml
+++ b/tests/Resources/Fixtures/config/etag_weak.yml
@@ -6,3 +6,4 @@ fos_http_cache:
                     path: null
                 headers:
                     etag: "weak"
+        ttl_header: X-Reverse-Proxy-TTL

--- a/tests/Resources/Fixtures/config/full.php
+++ b/tests/Resources/Fixtures/config/full.php
@@ -51,6 +51,7 @@ $container->loadFromExtension('fos_http_cache', [
                 ],
             ],
         ],
+        'ttl_header' => 'X-Reverse-Proxy-TTL',
     ],
     'proxy_client' => [
         'varnish' => [

--- a/tests/Resources/Fixtures/config/full.xml
+++ b/tests/Resources/Fixtures/config/full.xml
@@ -43,6 +43,7 @@
                     <vary>Authorization</vary>
                 </headers>
             </rule>
+            <ttl-header>X-Reverse-Proxy-TTL</ttl-header>
         </cache-control>
         <proxy-client>
             <varnish tags-header="My-Cache-Tags" header-length="1234">

--- a/tests/Resources/Fixtures/config/full.yml
+++ b/tests/Resources/Fixtures/config/full.yml
@@ -43,6 +43,7 @@ fos_http_cache:
                     vary:
                         - Cookie
                         - Authorization
+        ttl_header: X-Reverse-Proxy-TTL
     proxy_client:
         varnish:
             tags_header: My-Cache-Tags

--- a/tests/Resources/Fixtures/config/split.php
+++ b/tests/Resources/Fixtures/config/split.php
@@ -11,6 +11,7 @@
 
 $container->loadFromExtension('fos_http_cache', [
     'cache_control' => [
+        'ttl_header' => 'X-My-Header',
         'rules' => [
             [
                 'match' => [

--- a/tests/Resources/Fixtures/config/split.xml
+++ b/tests/Resources/Fixtures/config/split.xml
@@ -3,6 +3,7 @@
 
     <config xmlns="http://example.org/schema/dic/fos_http_cache">
         <cache-control>
+            <ttl-header>X-My-Header</ttl-header>
             <rule>
                 <match>
                     <methods>GET,POST</methods>

--- a/tests/Resources/Fixtures/config/split.yml
+++ b/tests/Resources/Fixtures/config/split.yml
@@ -1,6 +1,7 @@
 fos_http_cache:
 
     cache_control:
+        ttl_header: X-My-Header
         rules:
             -
                 match:

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -96,6 +96,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         ],
                     ],
                 ],
+                'ttl_header' => 'X-Reverse-Proxy-TTL',
             ],
             'proxy_client' => [
                 'varnish' => [
@@ -474,6 +475,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
     {
         $expectedConfiguration = $this->getEmptyConfig();
         $expectedConfiguration['cache_control'] = [
+            'ttl_header' => 'X-My-Header',
             'rules' => [
                 [
                     'match' => [
@@ -637,6 +639,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     ],
                 ],
             ],
+            'ttl_header' => 'X-Reverse-Proxy-TTL',
             'defaults' => [
                 'overwrite' => false,
             ],
@@ -679,6 +682,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     ],
                 ],
             ],
+            'ttl_header' => 'X-Reverse-Proxy-TTL',
             'defaults' => [
                 'overwrite' => false,
             ],

--- a/tests/Unit/EventListener/CacheControlListenerTest.php
+++ b/tests/Unit/EventListener/CacheControlListenerTest.php
@@ -334,6 +334,21 @@ class CacheControlListenerTest extends TestCase
         $this->assertEquals(600, $newHeaders['x-reverse-proxy-ttl'][0]);
     }
 
+    public function testReverseProxyTtlHeader(): void
+    {
+        $event = $this->buildEvent();
+        $headers = [
+            'reverse_proxy_ttl' => 700,
+        ];
+        $listener = $this->getCacheControl($headers, 'X-My-Header');
+
+        $listener->onKernelResponse($event);
+        $newHeaders = $event->getResponse()->headers->all();
+
+        $this->assertTrue(isset($newHeaders['x-my-header']), implode(',', array_keys($newHeaders)));
+        $this->assertEquals(700, $newHeaders['x-my-header'][0]);
+    }
+
     public function testDebugHeader(): void
     {
         $listener = new CacheControlListener('X-Cache-Debug');
@@ -426,9 +441,9 @@ class CacheControlListenerTest extends TestCase
      *
      * @param array $headers The headers to return from the matcher
      */
-    protected function getCacheControl(array $headers): CacheControlListener|MockObject
+    protected function getCacheControl(array $headers, string $ttlHeader = 'X-Reverse-Proxy-TTL'): CacheControlListener|MockObject
     {
-        $listener = new CacheControlListener();
+        $listener = new CacheControlListener(false, $ttlHeader);
 
         $matcher = \Mockery::mock(RuleMatcherInterface::class)
             ->shouldReceive(['matches' => true])


### PR DESCRIPTION
from https://github.com/FriendsOfSymfony/FOSHttpCache/pull/591

Fastly allows to cache via this https://www.fastly.com/documentation/reference/glossary/#term-surrogate-control header `Surrogate-Control`
(see also https://docs.fastly.com/en/guides/controlling-caching#setting-different-ttls-for-fastly-cache-and-web-browsers)

a specific origin response header, and this bundle allows to define a default value

this PR is allows to configure the ttl header name in the bundle avoid to create a fastly vcl or compute code for example