### PR TITLE
Remove outdated comment

### DIFF
--- a/src/EventListener/TagListener.php
+++ b/src/EventListener/TagListener.php
@@ -69,7 +69,6 @@ final class TagListener extends AbstractRuleListener implements EventSubscriberI
         if ($this->cacheableRule->matches($request, $response)) {
             // For safe requests (GET and HEAD), set cache tags on response
             $this->symfonyResponseTagger->addTags($tags);
-            // BC for symfony < 5.3
             if ($event->isMainRequest()) {
                 $this->symfonyResponseTagger->tagSymfonyResponse($response);
             }


### PR DESCRIPTION
The BC compatibility code has been removed [here](https://github.com/FriendsOfSymfony/FOSHttpCacheBundle/commit/a098964d295f8c0debd41c7b8f7d02c1a3621a7d#diff-d144984263e7f1c69d67ebace537ff3e5907196dcde77b49bc953725a9e2d3faR87) but the comment has been forgotten.