### PR TITLE
#643: Fix cache control expression Symfony DI configuration

### DIFF
--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -261,8 +261,8 @@ final class FOSHttpCacheExtension extends Extension
                 $childDefinition = (new ChildDefinition('fos_http_cache.response_matcher.cache_control.expression'))
                     ->setArgument(0, $config['match_response'])
                 ;
-                if (!empty($config['match_response_expression_service'])) {
-                    $childDefinition->replaceArgument(1, new Reference($config['match_response_expression_service']));
+                if (!empty($config['expression_language'])) {
+                    $childDefinition->setArgument(1, new Reference($config['expression_language']));
                 }
                 $container
                     ->setDefinition($id, $childDefinition)

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -259,7 +259,7 @@ final class FOSHttpCacheExtension extends Extension
             $id = 'fos_http_cache.cache_control.expression.'.md5($config['match_response']);
             if (!$container->hasDefinition($id)) {
                 $childDefinition = (new ChildDefinition('fos_http_cache.response_matcher.cache_control.expression'))
-                    ->replaceArgument(0, $config['match_response'])
+                    ->setArgument(0, $config['match_response'])
                 ;
                 if (!empty($config['match_response_expression_service'])) {
                     $childDefinition->replaceArgument(1, new Reference($config['match_response_expression_service']));

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Component\DependencyInjection\Exception\RuntimeException;
 use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBag;
 use Symfony\Component\DependencyInjection\Reference;
+use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
 use Symfony\Component\Routing\Router;
 
@@ -505,6 +506,20 @@ class FOSHttpCacheExtensionTest extends TestCase
             ],
             $container->getDefinition($id)->getArguments()
         );
+    }
+
+    public function testContainerCompilesWithCacheControlExpressionConfig(): void
+    {
+        $config = $this->getCacheControlExpressionFullConfig();
+
+        $container = $this->createContainer();
+        $this->extension->load([$config], $container);
+
+        $container->addDefinitions(['app.expression_language' => new Definition(ExpressionLanguage::class)]);
+
+        $container->compile();
+
+        $this->expectNotToPerformAssertions();
     }
 
     /**

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -489,6 +489,24 @@ class FOSHttpCacheExtensionTest extends TestCase
         $this->assertListenerHasRule($container, 'fos_http_cache.event_listener.cache_control');
     }
 
+    public function testConfigLoadCacheControlExpressionWithOverriddenExpressionLanguage(): void
+    {
+        $config = $this->getCacheControlExpressionFullConfig();
+
+        $container = $this->createContainer();
+        $this->extension->load([$config], $container);
+
+        $id = 'fos_http_cache.cache_control.expression.'.md5('foobar');
+        $this->assertTrue($container->hasDefinition($id), 'expression child definition not created as expected');
+        $this->assertEquals(
+            [
+                'foobar',
+                new Reference('app.expression_language'),
+            ],
+            $container->getDefinition($id)->getArguments()
+        );
+    }
+
     /**
      * Check if comma separated strings are parsed as expected.
      */
@@ -806,6 +824,28 @@ class FOSHttpCacheExtensionTest extends TestCase
                         'base_url' => 'my_hostname',
                         'servers' => [
                             '127.0.0.1',
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function getCacheControlExpressionFullConfig(): array
+    {
+        return [
+            'cache_control' => [
+                'rules' => [
+                    [
+                        'match' => [
+                            'match_response' => 'foobar',
+                            'expression_language' => 'app.expression_language',
+                        ],
+                        'headers' => [
+                            'cache_control' => ['public' => true],
                         ],
                     ],
                 ],


### PR DESCRIPTION
This PR fixes #643.

As described in #643, there are 2 issues with the current Extension configuration, when defined as follows:

```yaml
fos_http_cache:
    cache_control:
        rules:
            - match:
                  host: ^login.example.com$
                  match_response: 'response.isFresh()'
                  expression_language: 'app.expression_language'
              headers:
                  cache_control: {public: false}
```

1. When using `match_response` option, we get the following Container compile-time error:
     ```
     Service "fos_http_cache.cache_control.expression.e4ac4270c49eeac61019bc369235175a": Cannot replace arguments for class "FOS\HttpCacheBundle\Http\ResponseMatcher\ExpressionResponseMatcher" if none have been configured yet.
     ```
2. When using `match_response_expression_service`, we get an error that such option doesn't exist for the Extension. Seems `expression_language` should be used (as the Extension Configuration would suggest).

In both cases fixed `replaceArgument` to be `setArgument`. The former way worked in Symfony 5, but doesn't work in Symfony 6+.

The 1st issue occurs only at compile-time, therefore existing Extension tests configuring `match_response`  wouldn't surface the issue as the definition structure is correct. Seems Symfony now processes those differently at compile time.
I added `testContainerCompilesWithCacheControlExpressionConfig` which compiles the container and performs no other assertions. We can see the mentioned error on the current state of the `3.x` branch when running that test.

There's no coverage for 2nd argument, so I added `testConfigLoadCacheControlExpressionWithOverriddenExpressionLanguage` test.

Side note: Alternatively, adding the above options to `./tests/Functional/Fixtures/app/config/config.yml` config, would also uncover the bug when running any `KernelTestCase` test as those actually compile the container as well.