### PR TITLE
Add support for configurable HTTP request factory for proxy clients

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ Changelog
 2.x
 ===
 
+2.18.0
+------
+
+* New configuration option `proxy_client.*.http.request_factory` to support custom HTTP request factories for proxy clients.
+
 2.17.1
 ------
 

--- a/Resources/doc/features/invalidation.rst
+++ b/Resources/doc/features/invalidation.rst
@@ -66,7 +66,8 @@ To refresh paths and routes, you can use ``refreshPath($path, $headers)`` and
 
     If you want to add a header (such as ``Authorization``) to *all*
     invalidation requests, you can use a
-    :ref:`custom HTTP client <custom HTTP client>` instead.
+    :ref:`custom HTTP client <custom HTTP client>` or
+    :ref:`custom HTTP request factory <custom HTTP request factory>` instead.
 
 .. _invalidation configuration:
 

--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -405,7 +405,7 @@ configure a service for the ``HttpClient`` and specify that in the
 .. _custom HTTP request factory:
 
 Custom HTTP Request Factory
-------------------
+---------------------------
 
 The proxy client uses an implementation of ``Http\Message\RequestFactory`` to create HTTP requests.
 If you need to customize the request creation, you can configure your custom service and

--- a/Resources/doc/reference/configuration/proxy-client.rst
+++ b/Resources/doc/reference/configuration/proxy-client.rst
@@ -402,6 +402,15 @@ example to send a basic authentication header with each request, you can
 configure a service for the ``HttpClient`` and specify that in the
 ``http_client`` option of any of the cache proxy clients.
 
+.. _custom HTTP request factory:
+
+Custom HTTP Request Factory
+------------------
+
+The proxy client uses an implementation of ``Http\Message\RequestFactory`` to create HTTP requests.
+If you need to customize the request creation, you can configure your custom service and
+specify that in the ``request_factory`` option of any of the cache proxy clients.
+
 Caching Proxy Configuration
 ---------------------------
 

--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -641,6 +641,10 @@ class Configuration implements ConfigurationInterface
                     ->defaultNull()
                     ->info('Httplug async client service name to use for sending the requests.')
                 ->end()
+                ->scalarNode('request_factory')
+                    ->defaultNull()
+                    ->info('Service name of factory for PSR-7 messages.')
+                ->end()
             ->end()
         ;
 

--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -430,6 +430,12 @@ class FOSHttpCacheExtension extends Extension
         $container->setParameter('fos_http_cache.proxy_client.varnish.options', $options);
 
         $loader->load('varnish.xml');
+
+        $requestFactory = isset($config['http']['request_factory'])
+            ? new Reference($config['http']['request_factory'])
+            : null;
+        $container->getDefinition('fos_http_cache.proxy_client.varnish')
+            ->replaceArgument(2, $requestFactory);
     }
 
     private function loadNginx(ContainerBuilder $container, XmlFileLoader $loader, array $config)
@@ -439,6 +445,12 @@ class FOSHttpCacheExtension extends Extension
             'purge_location' => $config['purge_location'],
         ]);
         $loader->load('nginx.xml');
+
+        $requestFactory = isset($config['http']['request_factory'])
+            ? new Reference($config['http']['request_factory'])
+            : null;
+        $container->getDefinition('fos_http_cache.proxy_client.nginx')
+            ->replaceArgument(2, $requestFactory);
     }
 
     private function loadSymfony(ContainerBuilder $container, XmlFileLoader $loader, array $config)
@@ -465,6 +477,12 @@ class FOSHttpCacheExtension extends Extension
         $container->setParameter('fos_http_cache.proxy_client.symfony.options', $options);
 
         $loader->load('symfony.xml');
+
+        $requestFactory = isset($config['http']['request_factory'])
+            ? new Reference($config['http']['request_factory'])
+            : null;
+        $container->getDefinition('fos_http_cache.proxy_client.symfony')
+            ->replaceArgument(2, $requestFactory);
     }
 
     private function loadCloudflare(ContainerBuilder $container, XmlFileLoader $loader, array $config)
@@ -478,6 +496,12 @@ class FOSHttpCacheExtension extends Extension
         $container->setParameter('fos_http_cache.proxy_client.cloudflare.options', $options);
 
         $loader->load('cloudflare.xml');
+
+        $requestFactory = isset($config['http']['request_factory'])
+            ? new Reference($config['http']['request_factory'])
+            : null;
+        $container->getDefinition('fos_http_cache.proxy_client.cloudflare')
+            ->replaceArgument(2, $requestFactory);
     }
 
     private function loadCloudfront(ContainerBuilder $container, XmlFileLoader $loader, array $config)
@@ -514,6 +538,12 @@ class FOSHttpCacheExtension extends Extension
         $container->setParameter('fos_http_cache.proxy_client.fastly.options', $options);
 
         $loader->load('fastly.xml');
+
+        $requestFactory = isset($config['http']['request_factory'])
+            ? new Reference($config['http']['request_factory'])
+            : null;
+        $container->getDefinition('fos_http_cache.proxy_client.fastly')
+            ->replaceArgument(2, $requestFactory);
     }
 
     /**

--- a/src/Resources/config/cloudflare.xml
+++ b/src/Resources/config/cloudflare.xml
@@ -10,6 +10,7 @@
                  public="true">
             <argument type="service" id="fos_http_cache.proxy_client.cloudflare.http_dispatcher"/>
             <argument>%fos_http_cache.proxy_client.cloudflare.options%</argument>
+            <argument /> <!-- request factory -->
         </service>
     </services>
 

--- a/src/Resources/config/fastly.xml
+++ b/src/Resources/config/fastly.xml
@@ -10,6 +10,7 @@
                  public="false">
             <argument type="service" id="fos_http_cache.proxy_client.fastly.http_dispatcher"/>
             <argument>%fos_http_cache.proxy_client.fastly.options%</argument>
+            <argument /> <!-- request factory -->
         </service>
     </services>
 

--- a/src/Resources/config/nginx.xml
+++ b/src/Resources/config/nginx.xml
@@ -10,6 +10,7 @@
                  public="true">
             <argument type="service" id="fos_http_cache.proxy_client.nginx.http_dispatcher"/>
             <argument>%fos_http_cache.proxy_client.nginx.options%</argument>
+            <argument /> <!-- request factory -->
         </service>
     </services>
 

--- a/src/Resources/config/symfony.xml
+++ b/src/Resources/config/symfony.xml
@@ -10,6 +10,7 @@
                  public="true">
             <argument type="service" id="fos_http_cache.proxy_client.symfony.http_dispatcher"/>
             <argument>%fos_http_cache.proxy_client.symfony.options%</argument>
+            <argument /> <!-- request factory -->
         </service>
     </services>
 

--- a/src/Resources/config/varnish.xml
+++ b/src/Resources/config/varnish.xml
@@ -10,6 +10,7 @@
                  public="true">
             <argument type="service" id="fos_http_cache.proxy_client.varnish.http_dispatcher"/>
             <argument>%fos_http_cache.proxy_client.varnish.options%</argument>
+            <argument /> <!-- request factory -->
         </service>
     </services>
 

--- a/tests/Unit/DependencyInjection/ConfigurationTest.php
+++ b/tests/Unit/DependencyInjection/ConfigurationTest.php
@@ -105,6 +105,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                         'servers' => ['22.22.22.22'],
                         'base_url' => '/test',
                         'http_client' => 'acme.guzzle.varnish',
+                        'request_factory' => null,
                     ],
                 ],
             ],
@@ -241,6 +242,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'servers' => ['22.22.22.22'],
                     'base_url' => '/test',
                     'http_client' => 'acme.guzzle.nginx',
+                    'request_factory' => null,
                 ],
             ],
         ];
@@ -276,6 +278,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'servers' => ['22.22.22.22'],
                     'base_url' => '/test',
                     'http_client' => 'acme.guzzle.symfony',
+                    'request_factory' => null,
                 ],
                 'use_kernel_dispatcher' => false,
             ],
@@ -505,6 +508,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'base_url' => null,
                     'http_client' => null,
                     'servers' => ['1.1.1.1:80', '2.2.2.2:80'],
+                    'request_factory' => null,
                 ],
                 'tags_header' => 'X-Cache-Tags',
                 'tag_mode' => 'ban',
@@ -515,6 +519,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'base_url' => null,
                     'http_client' => null,
                     'servers' => ['1.1.1.1:81', '2.2.2.2:81'],
+                    'request_factory' => null,
                 ],
             ],
         ];
@@ -756,6 +761,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                 'servers' => ['localhost'],
                 'base_url' => null,
                 'http_client' => null,
+                'request_factory' => null,
             ];
             $expectedConfiguration['proxy_client'][$proxyClient]['purge_location'] = false;
         }
@@ -859,6 +865,7 @@ class ConfigurationTest extends AbstractExtensionConfigurationTestCase
                     'servers_from_jsonenv' => '%env(json:VARNISH_SERVERS)%',
                     'base_url' => '/test',
                     'http_client' => 'acme.guzzle.nginx',
+                    'request_factory' => null,
                 ],
                 'tag_mode' => 'ban',
                 'tags_header' => 'X-Cache-Tags',


### PR DESCRIPTION
It would be great if you could configure the third parameter of the `\FOS\HttpCache\ProxyClient\HttpProxyClient` without having to overwrite the entire service.