### PR TITLE
Set `FOS\HttpCache\ProxyClient\ProxyClient` class alias to default proxy client

### DIFF
--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -82,6 +82,10 @@ class FOSHttpCacheExtension extends Extension
                     'fos_http_cache.default_proxy_client',
                     $config['cache_manager']['custom_proxy_client']
                 );
+                $container->setAlias(
+                    ProxyClient::class,
+                    'fos_http_cache.default_proxy_client'
+                );
             }
             if ('auto' === $config['cache_manager']['generate_url_type']) {
                 if (array_key_exists('custom_proxy_client', $config['cache_manager'])) {


### PR DESCRIPTION
When only `cache_manager.custom_proxy_client` but no `proxy_client.*` is configured.