### PR TITLE
Bugfix: automatically detect url type generation for varnish

### DIFF
--- a/src/DependencyInjection/FOSHttpCacheExtension.php
+++ b/src/DependencyInjection/FOSHttpCacheExtension.php
@@ -745,9 +745,12 @@ final class FOSHttpCacheExtension extends Extension
         }
 
         $defaultClient = $this->getDefaultProxyClient($config['proxy_client']);
-        if ('noop' !== $defaultClient
-            && array_key_exists('base_url', $config['proxy_client'][$defaultClient])) {
-            return UrlGeneratorInterface::ABSOLUTE_PATH;
+        if ('noop' !== $defaultClient) {
+            $clientConfig = $config['proxy_client'][$defaultClient];
+            $hasBaseUrl = !empty($clientConfig['base_url'] ?? null) || !empty($clientConfig['http']['base_url'] ?? null);
+            if ($hasBaseUrl) {
+                return UrlGeneratorInterface::ABSOLUTE_PATH;
+            }
         }
         if ('cloudfront' === $defaultClient) {
             return UrlGeneratorInterface::ABSOLUTE_PATH;

--- a/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
+++ b/tests/Unit/DependencyInjection/FOSHttpCacheExtensionTest.php
@@ -28,6 +28,7 @@ use Symfony\Component\DependencyInjection\ParameterBag\EnvPlaceholderParameterBa
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Symfony\Component\HttpKernel\Controller\ControllerResolverInterface;
+use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Routing\Router;
 
 class FOSHttpCacheExtensionTest extends TestCase
@@ -51,6 +52,38 @@ class FOSHttpCacheExtensionTest extends TestCase
         $this->assertTrue($container->hasAlias('fos_http_cache.default_proxy_client'));
         $this->assertTrue($container->hasDefinition('fos_http_cache.event_listener.invalidation'));
         $this->assertTrue($container->hasDefinition('fos_http_cache.event_listener.tag'));
+    }
+
+    public function testVarnishWithBaseUrlAutoResolvesAbsolutePath(): void
+    {
+        $container = $this->createContainer();
+        $this->extension->load([$this->getBaseConfig()], $container);
+
+        $this->assertSame(
+            UrlGeneratorInterface::ABSOLUTE_PATH,
+            $container->getParameter('fos_http_cache.cache_manager.generate_url_type'),
+            'Varnish with base_url must auto-resolve to ABSOLUTE_PATH so the Host header uses base_url, not the CMS request hostname.'
+        );
+    }
+
+    public function testVarnishWithoutBaseUrlAutoResolvesAbsoluteUrl(): void
+    {
+        $container = $this->createContainer();
+        $config = [
+            'proxy_client' => [
+                'varnish' => [
+                    'http' => [
+                        'servers' => ['127.0.0.1'],
+                    ],
+                ],
+            ],
+        ];
+        $this->extension->load([$config], $container);
+
+        $this->assertSame(
+            UrlGeneratorInterface::ABSOLUTE_URL,
+            $container->getParameter('fos_http_cache.cache_manager.generate_url_type')
+        );
     }
 
     public function testConfigLoadVarnishCustomClient(): void


### PR DESCRIPTION
Dear @dbu,

I now stumbled upon a bug where `generate_url_type` must be set if you're using Varnish and `proxy_client.varnish.http.base_url`  is set. This is because the extension only takes `proxy_client.[client].base_url` into account, while Varnish client uses `proxy_client.varnish.http.base_url` (lacking "http" in array selector).

This PR fixes the automatic absolute/relative path generation if you use a combination of Varnish + custom base URL.